### PR TITLE
Explicitly specify the minimum required version of the `darling` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ bon = { path = "bon" }
 
 # Patch version 0.20.7 of darling added `flatten` feature. We use it, so we
 # need to specify an explicit patch version requirement
-darling      = "0.20.10"
+darling = "0.20.10"
 
 easy-ext     = "1.0"
 heck         = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,10 @@ repository = "https://github.com/elastio/bon"
 [workspace.dependencies]
 bon = { path = "bon" }
 
-darling      = "0.20"
+# Patch version 0.20.7 of darling added `flatten` feature. We use it, so we
+# need to specify an explicit patch version requirement
+darling      = "0.20.10"
+
 easy-ext     = "1.0"
 heck         = "0.5"
 itertools    = "0.13"


### PR DESCRIPTION
This fixes compile errors when adding `bon` to projects that already use an older version of `0.20` darling