### PR TITLE
add no_std support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,8 @@ jobs:
 
       - run: cargo test --locked --all-features --all-targets
       - run: cargo test --locked --all-features --doc
+      - run: cd bon && cargo test --locked --no-default-features --features=
+      - run: cd bon && cargo test --locked --no-default-features --features=alloc
 
   cargo-clippy:
     runs-on: ${{ matrix.os }}-latest

--- a/bon-macros/src/builder/builder_gen/mod.rs
+++ b/bon-macros/src/builder/builder_gen/mod.rs
@@ -391,7 +391,7 @@ impl BuilderGenCtx {
                         let qualified_for_into =
                             self.member_qualifies_for_into(member, &member.ty)?;
                         let default = if qualified_for_into {
-                            quote! { std::convert::Into::into((|| #default)()) }
+                            quote! { ::core::convert::Into::into((|| #default)()) }
                         } else {
                             quote! { #default }
                         };

--- a/bon/Cargo.toml
+++ b/bon/Cargo.toml
@@ -3,8 +3,14 @@ name = "bon"
 
 description = "Generate builders for everything!"
 
-categories = ["rust-patterns", "data-structures", "asynchronous"]
-keywords   = ["builder", "macro", "derive", "constructor", "setter"]
+categories = [
+  "rust-patterns",
+  "data-structures",
+  "asynchronous",
+  "no-std",
+  "no-std::no-alloc",
+]
+keywords = ["builder", "macro", "derive", "constructor", "setter"]
 
 edition    = { workspace = true }
 homepage   = { workspace = true }
@@ -25,3 +31,8 @@ bon-macros = { path = "../bon-macros", version = "=1.0.6" }
 expect-test = "1.5"
 tokio       = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 trybuild    = "1.0"
+
+[features]
+alloc   = []
+default = ["std"]
+std     = ["alloc"]

--- a/bon/src/lib.rs
+++ b/bon/src/lib.rs
@@ -33,6 +33,9 @@ pub mod private;
 ///
 /// This macro doesn't support `vec![expr; N]` syntax, since it's simpler to
 /// just write `vec![expr.into(); N]` using [`std::vec!`] instead.
+///
+/// This macro is only available if the `std` or the `alloc` feature is enabled. The
+/// `std` feature is enabled by default.
 #[macro_export]
 #[cfg(feature = "alloc")]
 macro_rules! vec {

--- a/bon/src/lib.rs
+++ b/bon/src/lib.rs
@@ -20,9 +20,9 @@ pub mod private;
 /// fn convert_media(input_extension: &str, output_extension: &str) -> std::io::Result<()> {
 ///     let ffmpeg_args: Vec<String> = bon::vec![
 ///         "-i",
-///         alloc::format!("input.{input_extension}"),
+///         format!("input.{input_extension}"),
 ///         "-y",
-///         alloc::format!("output.{output_extension}"),
+///         format!("output.{output_extension}"),
 ///     ];
 ///
 ///     std::process::Command::new("ffmpeg").args(ffmpeg_args).output()?;
@@ -79,7 +79,9 @@ macro_rules! arr {
 }
 
 #[cfg(test)]
+#[cfg(feature = "alloc")]
 mod tests {
+    use crate::private::alloc::{string::String, vec::Vec};
 
     #[test]
     fn arr_smoke() {
@@ -99,6 +101,7 @@ mod tests {
         assert!(actual.is_empty());
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn map_smoke() {
         use std::collections::BTreeMap;
@@ -121,6 +124,7 @@ mod tests {
         assert_eq!(tree_strings["Goodbye"], "Mars");
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn set_smoke() {
         use std::collections::BTreeSet;

--- a/bon/src/lib.rs
+++ b/bon/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 pub use bon_macros::*;
 
@@ -19,9 +20,9 @@ pub mod private;
 /// fn convert_media(input_extension: &str, output_extension: &str) -> std::io::Result<()> {
 ///     let ffmpeg_args: Vec<String> = bon::vec![
 ///         "-i",
-///         format!("input.{input_extension}"),
+///         alloc::format!("input.{input_extension}"),
 ///         "-y",
-///         format!("output.{output_extension}"),
+///         alloc::format!("output.{output_extension}"),
 ///     ];
 ///
 ///     std::process::Command::new("ffmpeg").args(ffmpeg_args).output()?;
@@ -33,9 +34,10 @@ pub mod private;
 /// This macro doesn't support `vec![expr; N]` syntax, since it's simpler to
 /// just write `vec![expr.into(); N]` using [`std::vec!`] instead.
 #[macro_export]
+#[cfg(feature = "alloc")]
 macro_rules! vec {
-    () => (::std::vec::Vec::new());
-    ($($item:expr),+ $(,)?) => (::std::vec![$(::core::convert::Into::into($item)),+ ]);
+    () => ($crate::private::alloc::vec::Vec::new());
+    ($($item:expr),+ $(,)?) => ($crate::private::alloc::vec![$(::core::convert::Into::into($item)),+ ]);
 }
 
 /// Creates a fixed-size array literal where each element is converted with [`Into::into()`]

--- a/bon/src/private.rs
+++ b/bon/src/private.rs
@@ -1,8 +1,12 @@
-#[derive(Debug)]
-pub struct Required<T>(pub std::marker::PhantomData<T>);
+/// Used to implement the `alloc` feature.
+#[cfg(feature = "alloc")]
+pub extern crate alloc;
 
 #[derive(Debug)]
-pub struct Optional<T>(pub std::marker::PhantomData<Option<T>>);
+pub struct Required<T>(pub core::marker::PhantomData<T>);
+
+#[derive(Debug)]
+pub struct Optional<T>(pub core::marker::PhantomData<Option<T>>);
 
 impl<T> From<Optional<T>> for Set<Option<T>> {
     #[inline(always)]

--- a/bon/tests/integration/builder_on_fn/expose_positional_fn.rs
+++ b/bon/tests/integration/builder_on_fn/expose_positional_fn.rs
@@ -43,9 +43,9 @@ fn with_nested_params() {
 #[test]
 fn simple() {
     #[builder(expose_positional_fn = positional)]
-    fn sut(arg1: String) -> String {
+    fn sut(arg1: u32) -> u32 {
         arg1
     }
 
-    assert_eq!(positional("arg1".to_owned()), "arg1");
+    assert_eq!(positional(42), 42);
 }

--- a/bon/tests/integration/builder_on_struct.rs
+++ b/bon/tests/integration/builder_on_struct.rs
@@ -15,8 +15,6 @@ fn smoke() {
 
         str_ref: &'a str,
 
-        string: String,
-
         #[builder(default)]
         u32: u32,
 
@@ -25,17 +23,14 @@ fn smoke() {
         option_u32: Option<u32>,
 
         option_str_ref: Option<&'a str>,
-        vec_string: Vec<String>,
         tuple: (u32, &'a [bool]),
     }
 
     let actual = Sut::builder()
         .bool(true)
         .str_ref("str_ref")
-        .string("string")
         .maybe_option_u32(Some(42))
         .option_str_ref("value")
-        .vec_string(vec!["String".to_owned()])
         .tuple((42, &[true, false]))
         .build();
 
@@ -43,7 +38,6 @@ fn smoke() {
         Sut {
             bool: true,
             str_ref: "str_ref",
-            string: "string",
             u32: 0,
             option_u32: Some(
                 42,
@@ -51,9 +45,6 @@ fn smoke() {
             option_str_ref: Some(
                 "value",
             ),
-            vec_string: [
-                "String",
-            ],
             tuple: (
                 42,
                 [
@@ -73,16 +64,16 @@ fn smoke() {
 fn raw_identifiers() {
     #[builder]
     struct r#Type {
-        r#type: String,
+        r#type: u32,
 
         #[builder(name = r#while)]
-        other: String,
+        other: u32,
     }
 
-    let actual = r#Type::builder().r#type("value").r#while("value2").build();
+    let actual = r#Type::builder().r#type(42).r#while(100).build();
 
-    assert_eq!(actual.r#type, "value");
-    assert_eq!(actual.other, "value2");
+    assert_eq!(actual.r#type, 42);
+    assert_eq!(actual.other, 100);
 
     #[builder(builder_type = r#type)]
     struct Sut {}

--- a/bon/tests/integration/main.rs
+++ b/bon/tests/integration/main.rs
@@ -1,4 +1,8 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(non_local_definitions)]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
 mod builder_on_fn;
 mod builder_on_struct;

--- a/website/docs/guide/overview.md
+++ b/website/docs/guide/overview.md
@@ -14,6 +14,24 @@ Add this to your `Cargo.toml` to use it:
 bon = "{{ versionWildcard }}"
 ```
 
+::: tip
+
+`bon` is compatible with `no_std` projects by disabling the default feature `std`. Add this to your `Cargo.toml` if you are in a `no_std` environment:
+
+```toml-vue
+[dependencies]
+bon = { version = "{{ versionWildcard }}", default-features = false }
+```
+
+If you do have `alloc` available, you can enable the `bon::vec` macro by setting the `alloc` feature:
+
+```toml-vue
+[dependencies]
+bon = { version = "{{ versionWildcard }}", default-features = false, features = ["alloc"] }
+```
+
+:::
+
 ## Builder for a function
 
 `bon` can turn a function with positional parameters into a function with "named" parameters via a builder. It's as easy as placing the `#[builder]` macro on top of it.


### PR DESCRIPTION
I wanted to try out `bon` in one of my `no_std` crates, but it turns out that `bon` does not have `no_std` support.

As a generator for builders, I could not see a reason why it would not have that, so here is a stab at adding `no_std` support. The example works for me, although I am sure I missed a spot or two ;).

Implementation was straightforward, with only `bon::vec!` requiring any thought at all, as the `alloc` crate is not available by default in either `std` or `no_std` configurations. I went the standard route of adding two features, `std` and `alloc`, with `std` enabled by default.
- If `std` is enabled, `bon::vec!` works as before and uses `std::vec`
- If `alloc` is enabled and `std` is not, `bon::vec!` uses `alloc::vec`
- If neither are enabled, `bon::vec!` is not available.