### PR TITLE
Followup docs improvements and more tests

### DIFF
--- a/bon/tests/integration/builder/init_order.rs
+++ b/bon/tests/integration/builder/init_order.rs
@@ -1,0 +1,71 @@
+use crate::prelude::*;
+
+// Functions don't support `skip` attributes
+#[test]
+fn fn_init_order() {
+    #[builder]
+    fn sut(
+        #[builder(default = 1)] arg1: u32,
+        #[builder(default = 2)] arg2: u32,
+        #[builder(default = [arg1, arg2, 3])] arg3: [u32; 3],
+    ) -> (u32, u32, [u32; 3]) {
+        (arg1, arg2, arg3)
+    }
+
+    assert_debug_eq(sut().call(), expect!["(1, 2, [1, 2, 3])"]);
+
+    // Make sure overriding the default works
+    assert_debug_eq(sut().arg1(4).call(), expect!["(4, 2, [4, 2, 3])"]);
+    assert_debug_eq(sut().arg2(5).call(), expect!["(1, 5, [1, 5, 3])"]);
+    assert_debug_eq(sut().arg3([6, 7, 8]).call(), expect!["(1, 2, [6, 7, 8])"]);
+}
+
+#[test]
+fn struct_init_order() {
+    #[builder]
+    #[derive(Debug)]
+    #[allow(dead_code)]
+    struct Sut {
+        #[builder(skip = 1)]
+        arg1: u32,
+
+        #[builder(default = 2)]
+        arg2: u32,
+
+        #[builder(skip = [arg1, arg2, 3])]
+        arg3: [u32; 3],
+    }
+
+    assert_debug_eq(
+        Sut::builder().build(),
+        expect!["Sut { arg1: 1, arg2: 2, arg3: [1, 2, 3] }"],
+    );
+
+    // Make sure overriding the default works
+    assert_debug_eq(
+        Sut::builder().arg2(4).build(),
+        expect!["Sut { arg1: 1, arg2: 4, arg3: [1, 4, 3] }"],
+    );
+
+    #[bon]
+    impl Sut {
+        #[builder]
+        fn sut(
+            #[builder(default = 1)] arg1: u32,
+            #[builder(default = 2)] arg2: u32,
+            #[builder(default = [arg1, arg2, 3])] arg3: [u32; 3],
+        ) -> (u32, u32, [u32; 3]) {
+            (arg1, arg2, arg3)
+        }
+    }
+
+    assert_debug_eq(Sut::sut().call(), expect!["(1, 2, [1, 2, 3])"]);
+
+    // Make sure overriding the default works
+    assert_debug_eq(Sut::sut().arg1(4).call(), expect!["(4, 2, [4, 2, 3])"]);
+    assert_debug_eq(Sut::sut().arg2(5).call(), expect!["(1, 5, [1, 5, 3])"]);
+    assert_debug_eq(
+        Sut::sut().arg3([6, 7, 8]).call(),
+        expect!["(1, 2, [6, 7, 8])"],
+    );
+}

--- a/bon/tests/integration/builder/mod.rs
+++ b/bon/tests/integration/builder/mod.rs
@@ -4,6 +4,7 @@ mod attr_into;
 mod attr_on;
 mod attr_skip;
 mod generics;
+mod init_order;
 mod lints;
 mod raw_idents;
 mod smoke;

--- a/bon/tests/integration/ui/compile_fail/misc.rs
+++ b/bon/tests/integration/ui/compile_fail/misc.rs
@@ -8,6 +8,18 @@ fn main() {
     };
 
     let set: BTreeSet<String> = bon::set!["mintals", "guns", "mintals", "roses"];
+
+    #[builder]
+    struct SkipGeneratesNoSetter {
+        #[builder(skip)]
+        x: u32,
+
+        #[builder(skip = 4)]
+        y: u32,
+    }
+
+    SkipGeneratesNoSetter::builder().x(42).build();
+    SkipGeneratesNoSetter::builder().y(42).build();
 }
 
 #[builder]

--- a/bon/tests/integration/ui/compile_fail/misc.stderr
+++ b/bon/tests/integration/ui/compile_fail/misc.stderr
@@ -23,115 +23,133 @@ error: duplicate value in the set
    |                                                              ^^^^^^^^^
 
 error: Only structs with named fields are supported
-  --> tests/integration/ui/compile_fail/misc.rs:14:1
+  --> tests/integration/ui/compile_fail/misc.rs:26:1
    |
-14 | struct TupleStruct(u32, u32);
+26 | struct TupleStruct(u32, u32);
    | ^^^^^^
 
 error: use a simple `identifier: type` syntax for the function argument; destructuring patterns in arguments aren't supported by the `#[builder]`
-  --> tests/integration/ui/compile_fail/misc.rs:17:18
+  --> tests/integration/ui/compile_fail/misc.rs:29:18
    |
-17 | fn destructuring((x, y): (u32, u32)) {
+29 | fn destructuring((x, y): (u32, u32)) {
    |                  ^^^^^^
 
 error: Unexpected type `bool`
-  --> tests/integration/ui/compile_fail/misc.rs:23:44
+  --> tests/integration/ui/compile_fail/misc.rs:35:44
    |
-23 | fn unnecessary_into_false(#[builder(into = false)] _x: u32) {}
+35 | fn unnecessary_into_false(#[builder(into = false)] _x: u32) {}
    |                                            ^^^^^
 
 error: this `#[builder(into)]` attribute is redundant, because `into` is already implied for this member via the `#[builder(on(...))]` at the top of the function
-  --> tests/integration/ui/compile_fail/misc.rs:26:31
+  --> tests/integration/ui/compile_fail/misc.rs:38:31
    |
-26 | fn unnecessary_into(#[builder(into)] _x: String) {}
+38 | fn unnecessary_into(#[builder(into)] _x: String) {}
    |                               ^^^^
 
 error: This syntax is not supported in type patterns yet. If you have a use case for this, please open an issue at https://github.com/elastio/bon/issues.
-  --> tests/integration/ui/compile_fail/misc.rs:28:15
+  --> tests/integration/ui/compile_fail/misc.rs:40:15
    |
-28 | #[builder(on(&dyn std::fmt::Debug, into))]
+40 | #[builder(on(&dyn std::fmt::Debug, into))]
    |               ^^^
 
 error: nested attributes are not allowed in the type pattern of #[builder(on(type_pattern, ...))]
-  --> tests/integration/ui/compile_fail/misc.rs:31:17
+  --> tests/integration/ui/compile_fail/misc.rs:43:17
    |
-31 | #[builder(on(fn(#[attr] a: u32), into))]
+43 | #[builder(on(fn(#[attr] a: u32), into))]
    |                 ^
 
 error: Expected an attribute of form `on(type_pattern, ...)`
-  --> tests/integration/ui/compile_fail/misc.rs:34:11
+  --> tests/integration/ui/compile_fail/misc.rs:46:11
    |
-34 | #[builder(on)]
+46 | #[builder(on)]
    |           ^^
 
 error: unexpected end of input, expected one of: `for`, parentheses, `fn`, `unsafe`, `extern`, identifier, `::`, `<`, `dyn`, square brackets, `*`, `&`, `!`, `impl`, `_`, lifetime
-  --> tests/integration/ui/compile_fail/misc.rs:37:1
+  --> tests/integration/ui/compile_fail/misc.rs:49:1
    |
-37 | #[builder(on())]
+49 | #[builder(on())]
    | ^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the attribute macro `builder` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected `,`
-  --> tests/integration/ui/compile_fail/misc.rs:40:1
+  --> tests/integration/ui/compile_fail/misc.rs:52:1
    |
-40 | #[builder(on(_))]
+52 | #[builder(on(_))]
    | ^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the attribute macro `builder` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this #[builder(on(type_pattern, ...))] contains no options to override the default behavior for the selected setters like `into`, so it does nothing
-  --> tests/integration/ui/compile_fail/misc.rs:43:1
+  --> tests/integration/ui/compile_fail/misc.rs:55:1
    |
-43 | #[builder(on(_,))]
+55 | #[builder(on(_,))]
    | ^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the attribute macro `builder` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected at least one parameter in parentheses
-  --> tests/integration/ui/compile_fail/misc.rs:46:11
+  --> tests/integration/ui/compile_fail/misc.rs:58:11
    |
-46 | #[builder(start_fn())]
+58 | #[builder(start_fn())]
    |           ^^^^^^^^
 
 error: `skip` attribute can't be specified with other attributes like `into` because there will be no setter generated for this member to configure
-  --> tests/integration/ui/compile_fail/misc.rs:51:21
+  --> tests/integration/ui/compile_fail/misc.rs:63:21
    |
-51 |     #[builder(skip, into)]
+63 |     #[builder(skip, into)]
    |                     ^^^^
 
 error: `skip` attribute can't be specified with other attributes like `name` because there will be no setter generated for this member to configure
-  --> tests/integration/ui/compile_fail/misc.rs:57:28
+  --> tests/integration/ui/compile_fail/misc.rs:69:28
    |
-57 |     #[builder(skip, name = bar)]
+69 |     #[builder(skip, name = bar)]
    |                            ^^^
 
 error: `skip` attribute can't be specified with other attributes like `default` because there will be no setter generated for this member to configure. If you wanted to specify a value for the member, then use the following syntax instead `#[builder(skip = value)]`
-  --> tests/integration/ui/compile_fail/misc.rs:63:21
+  --> tests/integration/ui/compile_fail/misc.rs:75:21
    |
-63 |     #[builder(skip, default = 42)]
+75 |     #[builder(skip, default = 42)]
    |                     ^^^^^^^
 
 error: `skip` attribute is not supported on function arguments. Use a local variable instead.
-  --> tests/integration/ui/compile_fail/misc.rs:69:15
+  --> tests/integration/ui/compile_fail/misc.rs:81:15
    |
-69 |     #[builder(skip)] _x: u32,
+81 |     #[builder(skip)] _x: u32,
    |               ^^^^
 
 error: Only structs with named fields are supported
-  --> tests/integration/ui/compile_fail/misc.rs:76:1
+  --> tests/integration/ui/compile_fail/misc.rs:88:1
    |
-76 | struct TupleStructsAreUnsupported(u32, u32);
+88 | struct TupleStructsAreUnsupported(u32, u32);
    | ^^^^^^
 
 error: The attribute is expected to be placed only on an `fn` item or a `struct` declaration
-  --> tests/integration/ui/compile_fail/misc.rs:79:1
+  --> tests/integration/ui/compile_fail/misc.rs:91:1
    |
-79 | enum EnumsAreUnsupported {}
+91 | enum EnumsAreUnsupported {}
    | ^^^^
 
 error: use a simple `identifier: type` syntax for the function argument; destructuring patterns in arguments aren't supported by the `#[builder]`
-  --> tests/integration/ui/compile_fail/misc.rs:82:39
+  --> tests/integration/ui/compile_fail/misc.rs:94:39
    |
-82 | fn destructuring_in_fn_is_unsupported((_, _): (u32, u32)) {}
+94 | fn destructuring_in_fn_is_unsupported((_, _): (u32, u32)) {}
    |                                       ^^^^^^
+
+error[E0599]: no method named `x` found for struct `SkipGeneratesNoSetterBuilder` in the current scope
+  --> tests/integration/ui/compile_fail/misc.rs:21:38
+   |
+12 |     #[builder]
+   |     ---------- method `x` not found for this struct
+...
+21 |     SkipGeneratesNoSetter::builder().x(42).build();
+   |                                      ^ method not found in `SkipGeneratesNoSetterBuilder`
+
+error[E0599]: no method named `y` found for struct `SkipGeneratesNoSetterBuilder` in the current scope
+  --> tests/integration/ui/compile_fail/misc.rs:22:38
+   |
+12 |     #[builder]
+   |     ---------- method `y` not found for this struct
+...
+22 |     SkipGeneratesNoSetter::builder().y(42).build();
+   |                                      ^ method not found in `SkipGeneratesNoSetterBuilder`

--- a/website/guide/alternatives.md
+++ b/website/guide/alternatives.md
@@ -8,23 +8,23 @@ There are several other existing alternative crates that generate builders. `bon
 
 <!-- If you want to edit the table below make sure to reduce the font size in editor or turn off word wrap to easier view the table -->
 
-Feature                                                  | `bon`              | [`buildstructor`]  | [`typed-builder`]                                                   | [`derive_builder`]
----------------------------------------------------------|--------------------|--------------------|---------------------------------------------------------------------|-------------------
-Builder for structs                                      | :white_check_mark: | :white_check_mark: | :white_check_mark:                                                  | :white_check_mark:
-Builder for free functions                               | :white_check_mark: |                    |                                                                     |
-Builder for associated methods                           | :white_check_mark: | :white_check_mark: |                                                                     |
-Panic safe                                               | :white_check_mark: | :white_check_mark: | :white_check_mark:                                                  | `build()` returns a `Result`
-Member of `Option` type is optional by default           | :white_check_mark: | :white_check_mark: | <span class="nobr">opt-in `#[builder(default)]`</span>              | <span class="nobr">opt-in `#[builder(default)]`</span>
-Making required member optional is compatible by default | :white_check_mark: | :white_check_mark: | <span class="nobr">opt-in `#[builder(setter(strip_option))]`</span> | <span class="nobr">opt-in `#[builder(setter(strip_option))]`</span>
-Generates `T::builder()` method                          | :white_check_mark: | :white_check_mark: | :white_check_mark:                                                  | only `Builder::default()`
-Automatic `Into` conversion in setters                   | :white_check_mark: | :white_check_mark: |                                                                     |
- `impl Trait` supported for functions                    | :white_check_mark: |                    |                                                                     |
-Anonymous lifetimes supported for functions              | :white_check_mark: |                    |                                                                     |
-`Self` mentions in functions/structs are supported       | :white_check_mark: |                    |                                                                     |
-Positional function is hidden by default                 | :white_check_mark: |                    |                                                                     |
-Special setter methods for collections                   | [(see below)][r1]  | :white_check_mark: |                                                                     | :white_check_mark:
-Custom methods can be added to the builder type          |                    |                    | :white_check_mark: ([mutators])                                     | :white_check_mark:
-Builder may be configured to use &self/&mut self         |                    |                    |                                                                     | :white_check_mark:
+Feature                                                  | `bon`                                                        | [`buildstructor`]               | [`typed-builder`]                                                   | [`derive_builder`]
+---------------------------------------------------------|--------------------------------------------------------------|---------------------------------|---------------------------------------------------------------------|-------------------
+Builder for structs                                      | :white_check_mark:                                           | :white_check_mark:              | :white_check_mark:                                                  | :white_check_mark:
+Builder for free functions                               | :white_check_mark:                                           |                                 |                                                                     |
+Builder for associated methods                           | :white_check_mark:                                           | :white_check_mark:              |                                                                     |
+Panic safe                                               | :white_check_mark:                                           | :white_check_mark:              | :white_check_mark:                                                  | `build()` returns a `Result`
+Member of `Option` type is optional by default           | :white_check_mark:                                           | :white_check_mark:              | <span class="nobr">opt-in `#[builder(default)]`</span>              | <span class="nobr">opt-in `#[builder(default)]`</span>
+Making required member optional is compatible by default | :white_check_mark:                                           | :white_check_mark:              | <span class="nobr">opt-in `#[builder(setter(strip_option))]`</span> | <span class="nobr">opt-in `#[builder(setter(strip_option))]`</span>
+Generates `T::builder()` method                          | :white_check_mark:                                           | :white_check_mark:              | :white_check_mark:                                                  | only `Builder::default()`
+`Into` conversion in setters                             | opt-in ([members subset][bon-on], [single member][bon-into]) | [implicit (automatic)][bs-into] | opt-in (all members + out-out, single member)                       | [opt-in (all members, single member)][db-into]
+ `impl Trait` supported for functions                    | :white_check_mark:                                           |                                 |                                                                     |
+Anonymous lifetimes supported for functions              | :white_check_mark:                                           |                                 |                                                                     |
+`Self` mentions in functions/structs are supported       | :white_check_mark:                                           |                                 |                                                                     |
+Positional function is hidden by default                 | :white_check_mark:                                           |                                 |                                                                     |
+Special setter methods for collections                   | [(see below)][r1]                                            | :white_check_mark:              |                                                                     | :white_check_mark:
+Custom methods can be added to the builder type          |                                                              |                                 | :white_check_mark: ([mutators])                                     | :white_check_mark:
+Builder may be configured to use &self/&mut self         |                                                              |                                 |                                                                     | :white_check_mark:
 
 ## Function builder fallback paradigm
 
@@ -61,7 +61,15 @@ This feature isn't available today in `bon`, but it's planned for the future. Ho
 
 The problem of this feature is that a setter that pushes an element into a collection like that may confuse the reader in case if only one element is pushed. This may hide the fact that the member is actually a collection called `friends` in plural. However, this feature is still useful to provide backwards-compatibility when changing the type of a member from `T` or `Option<T>` to `Collection<T>`.
 
-Alternatively, `bon` provides a separate solution. `bon` exposes `bon::vec![]`, `bon::map!{}`, and `bon::set![]` macros that include automatic `Into` conversion for every item. So in `bon` syntax it would look like this:
+Alternatively, `bon` provides a separate solution. `bon` exposes the following macros that provide convenient syntax to create collections.
+
+`Vec<T>`             | `[T; N]`             | `*Map<K, V>`         | `*Set<K, V>`
+---------------------|----------------------|----------------------|---------------------
+[`bon::vec![]`][vec] | [`bon::arr![]`][arr] | [`bon::map!{}`][map] | [`bon::set![]`][set]
+
+These macros share a common feature that every element of the collection is converted with `Into` to shorten the syntax if you, for example need to initialize a `Vec<String>` with items of type `&str`. Use these macros only if you need this behavior, or ignore them if you want to be explicit in code and avoid implicit `Into` conversions.
+
+**Example:**
 
 ```rust
 use bon::builder;
@@ -85,5 +93,13 @@ Another difference is that fields of collection types are considered required by
 [`buildstructor`]: https://docs.rs/buildstructor/latest/buildstructor/
 [`typed-builder`]: https://docs.rs/typed-builder/latest/typed_builder/
 [`derive_builder`]: https://docs.rs/derive_builder/latest/derive_builder/
+[vec]: https://docs.rs/bon/latest/bon/macro.vec.html
+[arr]: https://docs.rs/bon/latest/bon/macro.arr.html
+[map]: https://docs.rs/bon/latest/bon/macro.map.html
+[set]: https://docs.rs/bon/latest/bon/macro.set.html
 [mutators]: https://docs.rs/typed-builder/latest/typed_builder/derive.TypedBuilder.html#mutators
+[bon-on]: ../reference/builder#on
+[bon-into]: ../reference/builder#into
+[bs-into]: https://docs.rs/buildstructor/latest/buildstructor/#into-field
+[db-into]: https://docs.rs/derive_builder/latest/derive_builder/#generic-setters
 [r1]: #special-setter-methods-for-collections

--- a/website/reference/builder.md
+++ b/website/reference/builder.md
@@ -413,8 +413,8 @@ struct Example {
 
 Example::builder()
     .name("Bon")
-    // These members also matched the `String` type pattern,
-    // so `#[builder(into)]` was applied to it
+    // These members also match the `String` type pattern,
+    // so `#[builder(into)]` was applied to them
     .description("accepts an `impl Into<String>` here")
     .alias("builder")
     .build();


### PR DESCRIPTION
- Add a section for `None` literals inference drawbacks to "Into Conversions In-Depth"
- Update the "Alternatives" page according to the new into conversions behavior
- Fix grammar/typos
- Added more test cases for skip/default as per @blitzerr's suggestions: https://github.com/elastio/bon/pull/58/files#r1733772950