### PR TITLE
docs: improve builder() method docs

### DIFF
--- a/bon-macros/src/builder/builder_gen/input_struct.rs
+++ b/bon-macros/src/builder/builder_gen/input_struct.rs
@@ -132,7 +132,7 @@ impl StructInputCtx {
         };
 
         let start_func_docs = format!(
-            "Use builder syntax to create an instance of [`{}`]",
+            "Create an instance of [`{}`] using builder syntax",
             self.norm_struct.ident
         );
 


### PR DESCRIPTION
When I use an API I first care about the what, then how to achieve it. So reversing the statement feels better to me.