### PR TITLE
fix(clippy): don't warn on clippy::impl_trait_in_params

### DIFF
--- a/bon-macros/src/builder/builder_gen/setter_methods.rs
+++ b/bon-macros/src/builder/builder_gen/setter_methods.rs
@@ -271,6 +271,7 @@ impl<'a> MemberSettersCtx<'a> {
 
         quote! {
             #( #docs )*
+            #[allow(clippy::impl_trait_in_params)]
             #[inline(always)]
             #vis fn #method_name(self, #fn_params) -> #return_type {
                 #builder_ident {


### PR DESCRIPTION
fixes #78

Thought about adding [`unknown_lints`](https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#unknown-lints) too, but [`clippy::impl_trait_in_params` was added in 1.69](https://rust-lang.github.io/rust-clippy/master/index.html#/impl_trait_in_params) and the current MSRV seems to be 1.70 due to usage of [`is_some_and`](https://doc.rust-lang.org/std/option/enum.Option.html#method.is_some_and) (and similar methods) so `unknown_lints` can't happen for this lint.