### PR TITLE
feat: must_use on the finish function

### DIFF
--- a/bon-macros/src/builder/builder_gen/input_func.rs
+++ b/bon-macros/src/builder/builder_gen/input_func.rs
@@ -326,6 +326,7 @@ impl FuncInputCtx {
             ident: finish_func_ident,
             unsafety: self.norm_func.sig.unsafety,
             asyncness: self.norm_func.sig.asyncness,
+            must_use: get_must_use_attribute(&self.norm_func.attrs),
             body: Box::new(finish_func_body),
             output: self.norm_func.sig.output,
             docs: "Finishes building and performs the requested action.".to_owned(),
@@ -502,4 +503,28 @@ impl Visit<'_> for FindSelfReference {
             self.self_span = Some(first_segment.ident.span());
         }
     }
+}
+
+fn get_must_use_attribute(attrs: &[syn::Attribute]) -> Option<syn::Attribute> {
+    let mut iter = attrs
+        .iter()
+        .filter(|attr| !attr.is_doc() && matches!(attr.style, syn::AttrStyle::Outer))
+        .filter(|attr| {
+            let path = match &attr.meta {
+                syn::Meta::Path(path) => path,
+                syn::Meta::List(_) => return false,
+                syn::Meta::NameValue(name_value) => &name_value.path,
+            };
+            path.segments.len() == 1
+                && path
+                    .segments
+                    .iter()
+                    .any(|segment| segment.ident.raw_name() == "must_use")
+        });
+    let result = iter.next();
+    if iter.next().is_some() {
+        // Fishy: multiple must_use? panic here?
+        return None;
+    }
+    result.cloned()
 }

--- a/bon-macros/src/builder/builder_gen/input_struct.rs
+++ b/bon-macros/src/builder/builder_gen/input_struct.rs
@@ -126,6 +126,9 @@ impl StructInputCtx {
             ident: finish_func_ident,
             unsafety: None,
             asyncness: None,
+            must_use: Some(syn::parse_quote! {
+                #[must_use = "Building a struct without using it is likely a bug"]
+            }),
             body: Box::new(finish_func_body),
             output: syn::parse_quote!(-> #struct_ty),
             docs: "Finishes building and returns the requested object.".to_owned(),

--- a/bon-macros/src/builder/builder_gen/mod.rs
+++ b/bon-macros/src/builder/builder_gen/mod.rs
@@ -46,6 +46,8 @@ pub(crate) struct FinishFunc {
     pub(crate) ident: syn::Ident,
     pub(crate) unsafety: Option<syn::Token![unsafe]>,
     pub(crate) asyncness: Option<syn::Token![async]>,
+    /// <https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute>
+    pub(crate) must_use: Option<syn::Attribute>,
     pub(crate) body: Box<dyn FinishFuncBody>,
     pub(crate) output: syn::ReturnType,
     pub(crate) docs: String,
@@ -563,6 +565,7 @@ impl BuilderGenCtx {
         let body = &self.finish_func.body.generate(&member_exprs);
         let asyncness = &self.finish_func.asyncness;
         let unsafety = &self.finish_func.unsafety;
+        let must_use = &self.finish_func.must_use;
         let docs = &self.finish_func.docs;
         let vis = &self.vis;
         let builder_ident = &self.builder_ident;
@@ -605,6 +608,7 @@ impl BuilderGenCtx {
             {
                 #[doc = #docs]
                 #[inline(always)]
+                #must_use
                 #vis #asyncness #unsafety fn #finish_func_ident(self) #output {
                     #(#members_vars_decls)*
                     #body


### PR DESCRIPTION
closes #77

The implementation for cloning the `must_use` of the original function can likely be optimized. Wanted to bring this up to have something to discuss.

Maybe the `#[must_use = …]` of the original function should be removed as it could get "expensive" with this kind of usage: `#[must_use = include_str!("…")]`. It will only be called internally, so there is not much benefit of having the `must_use` there then?