### PR TITLE
chore(docs):  readme which describer full feature set for #112

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,14 @@
     /></a>
 </p>
 
-`bon` is a Rust crate for generating compile-time-checked builders for functions and structs.
+
+`bon` is a Rust crate for generating compile-time-checked builders for functions and structs, supporting partial struct building and idiomatic partial application with optional and named parameters for functions and methods.
 
 Visit the [guide for a complete overview of the crate](https://elastio.github.io/bon/guide/overview).
 
 ## Quick examples
 
-`bon` can turn a function with positional parameters into a function with "named" parameters via a builder. It's as easy as placing the `#[builder]` attribute on top of it.
+`bon` turns a function with positional parameters into a function with named parameters just by placing the `#[builder]` attribute on top of it.
 
 ```rust
 use bon::builder;


### PR DESCRIPTION
for https://github.com/elastio/bon/issues/112 

used `idiomatic` keyword because there are attempts to do partial application and named parameters in haskell/scala style which all non idiomatic and not nice looking Rust people expect.

so bon approach seems like nice fit