### PR TITLE
Make fields name in errors the same as names in struct

### DIFF
--- a/bon-macros/src/builder/builder_gen/mod.rs
+++ b/bon-macros/src/builder/builder_gen/mod.rs
@@ -129,7 +129,7 @@ impl Generics {
         }
     }
 
-    fn where_clause_predicates(&self) -> impl Iterator<Item=&syn::WherePredicate> {
+    fn where_clause_predicates(&self) -> impl Iterator<Item = &syn::WherePredicate> {
         self.where_clause
             .as_ref()
             .into_iter()
@@ -147,11 +147,11 @@ impl BuilderGenCtx {
         self.assoc_method_ctx.as_ref()?.receiver.as_ref()
     }
 
-    fn named_members(&self) -> impl Iterator<Item=&NamedMember> {
+    fn named_members(&self) -> impl Iterator<Item = &NamedMember> {
         self.members.iter().filter_map(Member::as_named)
     }
 
-    fn start_fn_args(&self) -> impl Iterator<Item=&StartFnArgMember> {
+    fn start_fn_args(&self) -> impl Iterator<Item = &StartFnArgMember> {
         self.members.iter().filter_map(Member::as_start_fn_arg)
     }
 
@@ -604,10 +604,7 @@ impl BuilderGenCtx {
     }
 
     fn inner_mod_label(&self) -> syn::Ident {
-        quote::format_ident!(
-            "{}__inner",
-            self.builder_ident.raw_name(),
-        )
+        quote::format_ident!("{}__inner", self.builder_ident.raw_name(),)
     }
 
     fn finish_method(&self) -> Result<TokenStream2> {

--- a/bon-macros/src/builder/builder_gen/mod.rs
+++ b/bon-macros/src/builder/builder_gen/mod.rs
@@ -205,8 +205,6 @@ impl BuilderGenCtx {
             .named_members()
             .map(Self::members_label);
 
-        let vis = &self.vis;
-
         let mod_name = &self.inner_mod_label();
 
         Ok(quote! {
@@ -214,9 +212,9 @@ impl BuilderGenCtx {
 
             #[doc(hidden)]
             #[allow(non_camel_case_types)]
-            #vis mod #mod_name {
+            mod #mod_name {
                 #(
-                    pub(super) struct #named_members_labels;
+                    pub struct #named_members_labels;
                 )*
             }
 
@@ -813,9 +811,5 @@ fn allow_warnings_on_member_types() -> TokenStream2 {
         //
         // And it triggers the warning. We just suppress it here.
         #[allow(unused_parens)]
-        // This working relates to structs used inside `IntoSet` for nicer error messages.
-        // These structs are not used by user, so warning relating to them not being
-        // available can be ignored.
-        #[allow(private_bounds)]
     }
 }

--- a/bon-macros/src/builder/builder_gen/mod.rs
+++ b/bon-macros/src/builder/builder_gen/mod.rs
@@ -203,7 +203,7 @@ impl BuilderGenCtx {
 
         let named_members_labels = self
             .named_members()
-            .map(|member| Self::members_label(member));
+            .map(Self::members_label);
 
         let vis = &self.vis;
 
@@ -813,5 +813,9 @@ fn allow_warnings_on_member_types() -> TokenStream2 {
         //
         // And it triggers the warning. We just suppress it here.
         #[allow(unused_parens)]
+        // This working relates to structs used inside `IntoSet` for nicer error messages.
+        // These structs are not used by user, so warning relating to them not being
+        // available can be ignored.
+        #[allow(private_bounds)]
     }
 }

--- a/bon-macros/src/builder/builder_gen/mod.rs
+++ b/bon-macros/src/builder/builder_gen/mod.rs
@@ -201,9 +201,7 @@ impl BuilderGenCtx {
 
         let allows = allow_warnings_on_member_types();
 
-        let named_members_labels = self
-            .named_members()
-            .map(Self::members_label);
+        let named_members_labels = self.named_members().map(Self::members_label);
 
         let mod_name = &self.inner_mod_label();
 

--- a/bon-macros/src/builder/builder_gen/mod.rs
+++ b/bon-macros/src/builder/builder_gen/mod.rs
@@ -203,7 +203,7 @@ impl BuilderGenCtx {
 
         let named_members_labels = self
             .named_members()
-            .map(|member| self.members_label(member));
+            .map(|member| Self::members_label(member));
 
         let vis = &self.vis;
 
@@ -593,13 +593,13 @@ impl BuilderGenCtx {
 
     /// Name of the dummy struct that is generated just to give a name for
     /// the member in the error message when `IntoSet` trait is not implemented.
-    fn members_label<'a>(&self, member: &'a NamedMember) -> &'a syn::Ident {
+    fn members_label(member: &NamedMember) -> &syn::Ident {
         member.setter_method_core_name()
     }
 
     fn absolute_members_label(&self, member: &NamedMember) -> TokenStream2 {
         let mode_label = &self.inner_mod_label();
-        let member_label = &self.members_label(member);
+        let member_label = &Self::members_label(member);
         quote!(#mode_label::#member_label)
     }
 

--- a/bon/tests/integration/ui/compile_fail/errors.stderr
+++ b/bon/tests/integration/ui/compile_fail/errors.stderr
@@ -193,14 +193,14 @@ error[E0599]: no method named `y` found for struct `SkipGeneratesNoSetterBuilder
 22 |     SkipGeneratesNoSetter::builder().y(42).build();
    |                                      ^ method not found in `SkipGeneratesNoSetterBuilder`
 
-error[E0277]: can't finish building yet; the member `ExampleBuilder__y` was not set
+error[E0277]: can't finish building yet; the member `y` was not set
   --> tests/integration/ui/compile_fail/errors.rs:34:37
    |
 34 |     let _ = Example::builder().x(1).build();
-   |                                     ^^^^^ the member `ExampleBuilder__y` was not set
+   |                                     ^^^^^ the member `y` was not set
    |
-   = help: the trait `IntoSet<u32, ExampleBuilder__y>` is not implemented for `Unset<Required>`
-   = help: the trait `IntoSet<Option<_>, ExampleBuilder__y>` is implemented for `Unset<Optional>`
+   = help: the trait `IntoSet<u32, y>` is not implemented for `Unset<Required>`
+   = help: the trait `IntoSet<Option<_>, y>` is implemented for `Unset<Optional>`
 note: required by a bound in `ExampleBuilder::<(__X, __Y, __Z)>::build`
   --> tests/integration/ui/compile_fail/errors.rs:24:14
    |
@@ -210,14 +210,14 @@ note: required by a bound in `ExampleBuilder::<(__X, __Y, __Z)>::build`
    |            ------- required by a bound in this associated function
    = note: this error originates in the derive macro `Builder` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: can't finish building yet; the member `ExampleBuilder__renamed` was not set
+error[E0277]: can't finish building yet; the member `renamed` was not set
   --> tests/integration/ui/compile_fail/errors.rs:34:37
    |
 34 |     let _ = Example::builder().x(1).build();
-   |                                     ^^^^^ the member `ExampleBuilder__renamed` was not set
+   |                                     ^^^^^ the member `renamed` was not set
    |
-   = help: the trait `IntoSet<u32, ExampleBuilder__renamed>` is not implemented for `Unset<Required>`
-   = help: the trait `IntoSet<Option<_>, ExampleBuilder__renamed>` is implemented for `Unset<Optional>`
+   = help: the trait `IntoSet<u32, renamed>` is not implemented for `Unset<Required>`
+   = help: the trait `IntoSet<Option<_>, renamed>` is implemented for `Unset<Optional>`
 note: required by a bound in `ExampleBuilder::<(__X, __Y, __Z)>::build`
   --> tests/integration/ui/compile_fail/errors.rs:24:14
    |
@@ -245,14 +245,14 @@ note: required by a bound in `ExampleBuilder::<(__X, __Y, __Z)>::y`
    |         - required by a bound in this associated function
    = note: this error originates in the derive macro `Builder` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: can't finish building yet; the member `SutBuilder__arg1` was not set
+error[E0277]: can't finish building yet; the member `arg1` was not set
   --> tests/integration/ui/compile_fail/errors.rs:47:32
    |
 47 |         let _ = Sut::builder().build();
-   |                                ^^^^^ the member `SutBuilder__arg1` was not set
+   |                                ^^^^^ the member `arg1` was not set
    |
-   = help: the trait `IntoSet<Option<u32>, SutBuilder__arg1>` is not implemented for `Unset<Required>`
-   = help: the trait `IntoSet<Option<u32>, SutBuilder__arg1>` is implemented for `Unset<Optional>`
+   = help: the trait `IntoSet<Option<u32>, arg1>` is not implemented for `Unset<Required>`
+   = help: the trait `IntoSet<Option<u32>, arg1>` is implemented for `Unset<Optional>`
    = help: for that trait implementation, expected `Optional`, found `Required`
 note: required by a bound in `SutBuilder::<(__Arg1,)>::build`
   --> tests/integration/ui/compile_fail/errors.rs:42:18


### PR DESCRIPTION
Also introduces private `mod` space where other elements can be put. This is very useful, because using this we can easily emulate names - `cargo doc` uses local name - so we can have multiple structs that are shown with the same name, but are completelly different.