### PR TITLE
`#[builder(on(_, transparent))]` attribute

### DIFF
--- a/bon-macros/src/builder/builder_gen/input_struct.rs
+++ b/bon-macros/src/builder/builder_gen/input_struct.rs
@@ -7,7 +7,6 @@ use crate::builder::builder_gen::models::{BuilderGenCtxParams, BuilderTypeParams
 use crate::normalization::{GenericsNamespace, SyntaxVariant};
 use crate::parsing::{ItemSigConfig, SpannedKey};
 use crate::util::prelude::*;
-use darling::FromMeta;
 use std::borrow::Cow;
 use syn::visit::Visit;
 use syn::visit_mut::VisitMut;
@@ -40,7 +39,7 @@ fn parse_top_level_config(item_struct: &syn::ItemStruct) -> Result<TopLevelConfi
         .into_iter()
         .concat();
 
-    TopLevelConfig::from_list(&meta)
+    TopLevelConfig::parse_for_struct(&meta)
 }
 
 pub(crate) struct StructInputCtx {

--- a/bon-macros/src/builder/builder_gen/member/named.rs
+++ b/bon-macros/src/builder/builder_gen/member/named.rs
@@ -259,6 +259,15 @@ impl NamedMember {
     }
 
     pub(crate) fn merge_on_config(&mut self, on: &[OnConfig]) -> Result {
+        // This is a temporary hack. We only allow `on(_, transparent)` as the
+        // first `on(...)` clause. Instead we should implement the extended design:
+        // https://github.com/elastio/bon/issues/152
+        if let Some(on) = on.first().filter(|on| on.transparent.is_present()) {
+            if self.is_special_option_ty() {
+                self.config.transparent = on.transparent;
+            }
+        }
+
         self.merge_config_into(on)?;
 
         // FIXME: refactor this to make it more consistent with `into`

--- a/bon-macros/src/builder/builder_gen/top_level_config/on.rs
+++ b/bon-macros/src/builder/builder_gen/top_level_config/on.rs
@@ -9,6 +9,7 @@ pub(crate) struct OnConfig {
     pub(crate) type_pattern: syn::Type,
     pub(crate) into: darling::util::Flag,
     pub(crate) overwritable: darling::util::Flag,
+    pub(crate) transparent: darling::util::Flag,
 }
 
 impl Parse for OnConfig {
@@ -22,6 +23,7 @@ impl Parse for OnConfig {
         struct Parsed {
             into: darling::util::Flag,
             overwritable: darling::util::Flag,
+            transparent: darling::util::Flag,
         }
 
         let parsed = Parsed::from_meta(&syn::parse_quote!(on(#rest)))?;
@@ -31,8 +33,16 @@ impl Parse for OnConfig {
             // This lives in a separate block to make sure that if a new
             // field is added to `Parsed` and unused here, then a compiler
             // warning is emitted.
-            let Parsed { into, overwritable } = &parsed;
-            let flags = [("into", into), ("overwritable", overwritable)];
+            let Parsed {
+                into,
+                overwritable,
+                transparent,
+            } = &parsed;
+            let flags = [
+                ("into", into),
+                ("overwritable", overwritable),
+                ("transparent", transparent),
+            ];
 
             if flags.iter().all(|(_, flag)| !flag.is_present()) {
                 let flags = flags.iter().map(|(name, _)| format!("`{name}`")).join(", ");
@@ -76,12 +86,17 @@ impl Parse for OnConfig {
             "BUG: the type pattern does not match itself: {type_pattern:#?}"
         );
 
-        let Parsed { into, overwritable } = parsed;
+        let Parsed {
+            into,
+            overwritable,
+            transparent,
+        } = parsed;
 
         Ok(Self {
             type_pattern,
             into,
             overwritable,
+            transparent,
         })
     }
 }

--- a/bon/tests/integration/builder/attr_transparent.rs
+++ b/bon/tests/integration/builder/attr_transparent.rs
@@ -1,85 +1,58 @@
-use crate::prelude::*;
-use core::fmt;
+mod member_level {
+    use crate::prelude::*;
+    use core::fmt;
 
-#[test]
-fn test_struct() {
-    #[derive(Debug, Builder)]
-    #[allow(dead_code)]
-    struct Sut<T> {
-        #[builder(transparent)]
-        regular: Option<u32>,
+    #[test]
+    fn test_struct() {
+        #[derive(Debug, Builder)]
+        #[allow(dead_code)]
+        struct Sut<T> {
+            #[builder(transparent)]
+            regular: Option<u32>,
 
-        #[builder(transparent)]
-        generic: Option<T>,
+            #[builder(transparent)]
+            generic: Option<T>,
 
-        #[builder(transparent, into)]
-        with_into: Option<u32>,
+            #[builder(transparent, into)]
+            with_into: Option<u32>,
 
-        #[builder(transparent, default = Some(99))]
-        with_default: Option<u32>,
+            #[builder(transparent, default = Some(99))]
+            with_default: Option<u32>,
 
-        #[builder(transparent, default = Some(10))]
-        with_default_2: Option<u32>,
+            #[builder(transparent, default = Some(10))]
+            with_default_2: Option<u32>,
+        }
+
+        assert_debug_eq(
+            Sut::builder()
+                .regular(Some(1))
+                .generic(Some(false))
+                .with_into(2)
+                .maybe_with_default_2(Some(Some(3)))
+                .build(),
+            expect![[r#"
+                Sut {
+                    regular: Some(
+                        1,
+                    ),
+                    generic: Some(
+                        false,
+                    ),
+                    with_into: Some(
+                        2,
+                    ),
+                    with_default: Some(
+                        99,
+                    ),
+                    with_default_2: Some(
+                        3,
+                    ),
+                }"#]],
+        );
     }
 
-    assert_debug_eq(
-        Sut::builder()
-            .regular(Some(1))
-            .generic(Some(false))
-            .with_into(2)
-            .maybe_with_default_2(Some(Some(3)))
-            .build(),
-        expect![[r#"
-            Sut {
-                regular: Some(
-                    1,
-                ),
-                generic: Some(
-                    false,
-                ),
-                with_into: Some(
-                    2,
-                ),
-                with_default: Some(
-                    99,
-                ),
-                with_default_2: Some(
-                    3,
-                ),
-            }"#]],
-    );
-}
-
-#[test]
-fn test_free_fn() {
-    #[builder]
-    fn sut<T: fmt::Debug>(
-        #[builder(transparent)] regular: Option<u32>,
-        #[builder(transparent)] generic: Option<T>,
-        #[builder(transparent, into)] with_into: Option<u32>,
-        #[builder(transparent, default = Some(99))] with_default: Option<u32>,
-        #[builder(transparent, default = Some(10))] with_default_2: Option<u32>,
-    ) -> impl fmt::Debug {
-        (regular, generic, with_into, with_default, with_default_2)
-    }
-
-    assert_debug_eq(
-        sut()
-            .regular(Some(1))
-            .generic(Some(false))
-            .with_into(2)
-            .maybe_with_default_2(Some(Some(3)))
-            .call(),
-        expect!["(Some(1), Some(false), Some(2), Some(99), Some(3))"],
-    );
-}
-
-#[test]
-fn test_assoc_method() {
-    struct Sut;
-
-    #[bon]
-    impl Sut {
+    #[test]
+    fn test_free_fn() {
         #[builder]
         fn sut<T: fmt::Debug>(
             #[builder(transparent)] regular: Option<u32>,
@@ -91,37 +64,194 @@ fn test_assoc_method() {
             (regular, generic, with_into, with_default, with_default_2)
         }
 
-        #[builder]
-        fn with_self<T: fmt::Debug>(
-            &self,
-            #[builder(transparent)] regular: Option<u32>,
-            #[builder(transparent)] generic: Option<T>,
-            #[builder(transparent, into)] with_into: Option<u32>,
-            #[builder(transparent, default = Some(99))] with_default: Option<u32>,
-            #[builder(transparent, default = Some(10))] with_default_2: Option<u32>,
-        ) -> impl fmt::Debug {
-            let _ = self;
-            (regular, generic, with_into, with_default, with_default_2)
-        }
+        assert_debug_eq(
+            sut()
+                .regular(Some(1))
+                .generic(Some(false))
+                .with_into(2)
+                .maybe_with_default_2(Some(Some(3)))
+                .call(),
+            expect!["(Some(1), Some(false), Some(2), Some(99), Some(3))"],
+        );
     }
 
-    assert_debug_eq(
-        Sut::sut()
-            .regular(Some(1))
-            .generic(Some(false))
-            .with_into(2)
-            .maybe_with_default_2(Some(Some(3)))
-            .call(),
-        expect!["(Some(1), Some(false), Some(2), Some(99), Some(3))"],
-    );
+    #[test]
+    fn test_assoc_method() {
+        struct Sut;
 
-    assert_debug_eq(
-        Sut.with_self()
-            .regular(Some(1))
-            .generic(Some(false))
-            .with_into(2)
-            .maybe_with_default_2(Some(Some(3)))
-            .call(),
-        expect!["(Some(1), Some(false), Some(2), Some(99), Some(3))"],
-    );
+        #[bon]
+        impl Sut {
+            #[builder]
+            fn sut<T: fmt::Debug>(
+                #[builder(transparent)] regular: Option<u32>,
+                #[builder(transparent)] generic: Option<T>,
+                #[builder(transparent, into)] with_into: Option<u32>,
+                #[builder(transparent, default = Some(99))] with_default: Option<u32>,
+                #[builder(transparent, default = Some(10))] with_default_2: Option<u32>,
+            ) -> impl fmt::Debug {
+                (regular, generic, with_into, with_default, with_default_2)
+            }
+
+            #[builder]
+            fn with_self<T: fmt::Debug>(
+                &self,
+                #[builder(transparent)] regular: Option<u32>,
+                #[builder(transparent)] generic: Option<T>,
+                #[builder(transparent, into)] with_into: Option<u32>,
+                #[builder(transparent, default = Some(99))] with_default: Option<u32>,
+                #[builder(transparent, default = Some(10))] with_default_2: Option<u32>,
+            ) -> impl fmt::Debug {
+                let _ = self;
+                (regular, generic, with_into, with_default, with_default_2)
+            }
+        }
+
+        assert_debug_eq(
+            Sut::sut()
+                .regular(Some(1))
+                .generic(Some(false))
+                .with_into(2)
+                .maybe_with_default_2(Some(Some(3)))
+                .call(),
+            expect!["(Some(1), Some(false), Some(2), Some(99), Some(3))"],
+        );
+
+        assert_debug_eq(
+            Sut.with_self()
+                .regular(Some(1))
+                .generic(Some(false))
+                .with_into(2)
+                .maybe_with_default_2(Some(Some(3)))
+                .call(),
+            expect!["(Some(1), Some(false), Some(2), Some(99), Some(3))"],
+        );
+    }
+}
+
+mod attr_on {
+    use crate::prelude::*;
+    use core::fmt;
+
+    #[test]
+    fn test_struct() {
+        #[derive(Debug, Builder)]
+        #[builder(on(_, transparent))]
+        #[allow(dead_code)]
+        struct Sut<T> {
+            regular: Option<u32>,
+            generic: Option<T>,
+
+            #[builder(into)]
+            with_into: Option<u32>,
+
+            #[builder(default = Some(99))]
+            with_default: Option<u32>,
+
+            #[builder(default = Some(10))]
+            with_default_2: Option<u32>,
+        }
+
+        assert_debug_eq(
+            Sut::builder()
+                .regular(Some(1))
+                .generic(Some(false))
+                .with_into(2)
+                .maybe_with_default_2(Some(Some(3)))
+                .build(),
+            expect![[r#"
+                Sut {
+                    regular: Some(
+                        1,
+                    ),
+                    generic: Some(
+                        false,
+                    ),
+                    with_into: Some(
+                        2,
+                    ),
+                    with_default: Some(
+                        99,
+                    ),
+                    with_default_2: Some(
+                        3,
+                    ),
+                }"#]],
+        );
+    }
+
+    #[test]
+    fn test_free_fn() {
+        #[builder(on(_, transparent))]
+        fn sut<T: fmt::Debug>(
+            regular: Option<u32>,
+            generic: Option<T>,
+            #[builder(into)] with_into: Option<u32>,
+            #[builder(default = Some(99))] with_default: Option<u32>,
+            #[builder(default = Some(10))] with_default_2: Option<u32>,
+        ) -> impl fmt::Debug {
+            (regular, generic, with_into, with_default, with_default_2)
+        }
+
+        assert_debug_eq(
+            sut()
+                .regular(Some(1))
+                .generic(Some(false))
+                .with_into(2)
+                .maybe_with_default_2(Some(Some(3)))
+                .call(),
+            expect!["(Some(1), Some(false), Some(2), Some(99), Some(3))"],
+        );
+    }
+
+    #[test]
+    fn test_assoc_method() {
+        struct Sut;
+
+        #[bon]
+        impl Sut {
+            #[builder(on(_, transparent))]
+            fn sut<T: fmt::Debug>(
+                regular: Option<u32>,
+                generic: Option<T>,
+                #[builder(into)] with_into: Option<u32>,
+                #[builder(default = Some(99))] with_default: Option<u32>,
+                #[builder(default = Some(10))] with_default_2: Option<u32>,
+            ) -> impl fmt::Debug {
+                (regular, generic, with_into, with_default, with_default_2)
+            }
+
+            #[builder(on(_, transparent))]
+            fn with_self<T: fmt::Debug>(
+                &self,
+                regular: Option<u32>,
+                generic: Option<T>,
+                #[builder(into)] with_into: Option<u32>,
+                #[builder(default = Some(99))] with_default: Option<u32>,
+                #[builder(default = Some(10))] with_default_2: Option<u32>,
+            ) -> impl fmt::Debug {
+                let _ = self;
+                (regular, generic, with_into, with_default, with_default_2)
+            }
+        }
+
+        assert_debug_eq(
+            Sut::sut()
+                .regular(Some(1))
+                .generic(Some(false))
+                .with_into(2)
+                .maybe_with_default_2(Some(Some(3)))
+                .call(),
+            expect!["(Some(1), Some(false), Some(2), Some(99), Some(3))"],
+        );
+
+        assert_debug_eq(
+            Sut.with_self()
+                .regular(Some(1))
+                .generic(Some(false))
+                .with_into(2)
+                .maybe_with_default_2(Some(Some(3)))
+                .call(),
+            expect!["(Some(1), Some(false), Some(2), Some(99), Some(3))"],
+        );
+    }
 }

--- a/bon/tests/integration/ui/compile_fail/attr_on.rs
+++ b/bon/tests/integration/ui/compile_fail/attr_on.rs
@@ -24,4 +24,34 @@ fn incomplete_on3() {}
 #[builder(on(_,))]
 fn incomplete_on4() {}
 
+#[builder(
+    on(_, transparent),
+    finish_fn = finish,
+    on(String, into),
+)]
+fn non_consecutive_on1() {}
+
+#[builder(
+    start_fn = start,
+    on(_, transparent),
+    finish_fn = finish,
+    on(String, into),
+)]
+fn non_consecutive_on2() {}
+
+#[builder(
+    start_fn = start,
+    on(_, transparent),
+    finish_fn = finish,
+    on(String, into),
+    builder_type = Builder,
+)]
+fn non_consecutive_on3() {}
+
+#[builder(on(_, into), on(_, transparent))]
+fn non_first_transparent() {}
+
+#[builder(on(u8, transparent))]
+fn non_wildcard_transparent() {}
+
 fn main() {}

--- a/bon/tests/integration/ui/compile_fail/attr_on.stderr
+++ b/bon/tests/integration/ui/compile_fail/attr_on.stderr
@@ -42,10 +42,40 @@ error: expected `,`
    |
    = note: this error originates in the attribute macro `builder` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: this #[builder(on(type_pattern, ...))] contains no options to override the default behavior for the selected setters like `into`, `overwritable`, so it does nothing
+error: this #[builder(on(type_pattern, ...))] contains no options to override the default behavior for the selected setters like `into`, `overwritable`, `transparent`, so it does nothing
   --> tests/integration/ui/compile_fail/attr_on.rs:24:1
    |
 24 | #[builder(on(_,))]
    | ^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the attribute macro `builder` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: this `on(...)` clause is out of order; all `on(...)` clauses must be consecutive; there shouldn't be any other parameters between them
+  --> tests/integration/ui/compile_fail/attr_on.rs:30:5
+   |
+30 |     on(String, into),
+   |     ^^
+
+error: this `on(...)` clause is out of order; all `on(...)` clauses must be consecutive; there shouldn't be any other parameters between them
+  --> tests/integration/ui/compile_fail/attr_on.rs:38:5
+   |
+38 |     on(String, into),
+   |     ^^
+
+error: this `on(...)` clause is out of order; all `on(...)` clauses must be consecutive; there shouldn't be any other parameters between them
+  --> tests/integration/ui/compile_fail/attr_on.rs:46:5
+   |
+46 |     on(String, into),
+   |     ^^
+
+error: `transparent` can only be specified in the first `on(...)` clause; this restriction may be lifted in the future
+  --> tests/integration/ui/compile_fail/attr_on.rs:51:30
+   |
+51 | #[builder(on(_, into), on(_, transparent))]
+   |                              ^^^^^^^^^^^
+
+error: `transparent` can only be used with the wildcard type pattern i.e. `on(_, transparent)`; this restriction may be lifted in the future
+  --> tests/integration/ui/compile_fail/attr_on.rs:54:14
+   |
+54 | #[builder(on(u8, transparent))]
+   |              ^^


### PR DESCRIPTION
Implements the `#[builder(on(_, transparent)]` that is part of https://github.com/elastio/bon/issues/35.

Unfortunately, this initial implementation is a bit limited (but still useful!). There are two restrictions:
-  It's only possible to specify `#[builder(on(_, transparent))]` with an `_` pattern. No other patterns will be accepted (compile error)
- It's only possible to specify `transparent` in the first `on`. This doesn't compile: `#[builder(on(String, into), on(_, transparent))]`. Reorder the clauses to this instead: `#[builder(on(_, transparent), on(String, into))]`

I decided to postpone the extended design https://github.com/elastio/bon/issues/152 for `on` for later. It's a really complex feature that I'd rather not do as part of the initial `3.0`. It's possible to implement that in a minor release (no breaking changes are expected).

This PR doesn't include the documentation for this feature. The docs for all the new behaviors and attributes will be submitted in a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error messages for the `#[builder(...)]` attribute usage, addressing redundancy, unsupported syntax, and nested attributes.
	- Clarified requirements for `on(...)` clauses, including order and parameter specifications.
	- Enhanced guidance for using the `transparent` option within `on(...)` clauses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->