### PR TITLE
Fix `unexpected_cfg` lint coming from `#[cfg(rust_analyzer)]`

### DIFF
--- a/bon-macros/src/builder/builder_gen/mod.rs
+++ b/bon-macros/src/builder/builder_gen/mod.rs
@@ -150,17 +150,19 @@ impl BuilderGenCtx {
             // provided inside of the block to figure out the semantic meaning of
             // the tokens passed to the attribute.
             #[allow(unexpected_cfgs)]
-            #[cfg(rust_analyzer)]
             {
-                // Let IDEs know that these are type patterns like the ones that
-                // could be written in a type annotation for a variable. Note that
-                // we don't initialize the variable with any value because we don't
-                // have any meaningful value to assign to this variable, especially
-                // because its type may contain wildcard patterns like `_`. This is
-                // used only to signal the IDEs that these tokens are meant to be
-                // type patterns by placing them in the context where type patterns
-                // are expected.
-                let _: (#(#type_patterns,)*);
+                #[cfg(rust_analyzer)]
+                {
+                    // Let IDEs know that these are type patterns like the ones that
+                    // could be written in a type annotation for a variable. Note that
+                    // we don't initialize the variable with any value because we don't
+                    // have any meaningful value to assign to this variable, especially
+                    // because its type may contain wildcard patterns like `_`. This is
+                    // used only to signal the IDEs that these tokens are meant to be
+                    // type patterns by placing them in the context where type patterns
+                    // are expected.
+                    let _: (#(#type_patterns,)*);
+                }
             }
         }
     }

--- a/bon-macros/src/builder/builder_gen/mod.rs
+++ b/bon-macros/src/builder/builder_gen/mod.rs
@@ -149,6 +149,7 @@ impl BuilderGenCtx {
             // compiled by `rustc`. Rust Analyzer should be able to use the syntax
             // provided inside of the block to figure out the semantic meaning of
             // the tokens passed to the attribute.
+            #[allow(unexpected_cfgs)]
             #[cfg(rust_analyzer)]
             {
                 // Let IDEs know that these are type patterns like the ones that

--- a/bon-macros/src/util/ide.rs
+++ b/bon-macros/src/util/ide.rs
@@ -176,6 +176,7 @@ pub(crate) fn generate_completion_triggers(meta: Vec<Meta>) -> TokenStream {
         // The special `rust_analyzer` CFG is enabled only when Rust Analyzer is
         // running its code analysis. This allows us to provide code that is
         // useful only for Rust Analyzer for it to provide hints and completions.
+        #[allow(unexpected_cfgs)]
         #[cfg(rust_analyzer)]
         const _: () = {
             #completion_triggers

--- a/bon-macros/src/util/ide.rs
+++ b/bon-macros/src/util/ide.rs
@@ -177,9 +177,11 @@ pub(crate) fn generate_completion_triggers(meta: Vec<Meta>) -> TokenStream {
         // running its code analysis. This allows us to provide code that is
         // useful only for Rust Analyzer for it to provide hints and completions.
         #[allow(unexpected_cfgs)]
-        #[cfg(rust_analyzer)]
         const _: () = {
-            #completion_triggers
+            #[cfg(rust_analyzer)]
+            {
+                #completion_triggers
+            }
         };
     }
 }

--- a/bon-sandbox/src/docs_comparison/methods.rs
+++ b/bon-sandbox/src/docs_comparison/methods.rs
@@ -30,6 +30,10 @@ pub mod bon {
 
 /// Example docs generated with `buildstructor`
 #[expect(elided_lifetimes_in_paths)]
+// `buildstructor` generates a `#[cfg_attr(feature = "cargo-clippy", ...)]`,
+// which is not known to rustc. This lint comes from `nightly` at the time
+// of this writing, so using `allow` for now instead of `expect`
+#[allow(unexpected_cfgs)]
 pub mod buildstructor {
 
     /// Doc comment on `Struct`

--- a/bon-sandbox/src/docs_comparison/structs.rs
+++ b/bon-sandbox/src/docs_comparison/structs.rs
@@ -20,6 +20,10 @@ pub mod bon {
 }
 
 /// Example docs generated with `buildstructor`
+// `buildstructor` generates a `#[cfg_attr(feature = "cargo-clippy", ...)]`,
+// which is not known to rustc. This lint comes from `nightly` at the time
+// of this writing, so using `allow` for now instead of `expect`
+#[allow(unexpected_cfgs)]
 pub mod buildstructor {
     /// Doc comment on `Struct`
     #[derive(buildstructor::Builder)]


### PR DESCRIPTION
Closes #211