### PR TITLE
Make `self` receiver and `start_fn` members available as official fields

### DIFF
--- a/bon-macros/src/builder/builder_gen/builder_decl.rs
+++ b/bon-macros/src/builder/builder_gen/builder_decl.rs
@@ -37,10 +37,10 @@ impl super::BuilderGenCtx {
         };
 
         let receiver_field = self.receiver().map(|receiver| {
+            let ident = &receiver.field_ident;
             let ty = &receiver.without_self_keyword;
             quote! {
-                #private_field_attrs
-                __unsafe_private_receiver: #ty,
+                #ident: #ty,
             }
         });
 
@@ -51,17 +51,8 @@ impl super::BuilderGenCtx {
 
         let allows = super::allow_warnings_on_member_types();
 
-        let mut start_fn_arg_types = self
-            .start_fn_args()
-            .map(|member| &member.base.ty.norm)
-            .peekable();
-
-        let start_fn_args_field = start_fn_arg_types.peek().is_some().then(|| {
-            quote! {
-                #private_field_attrs
-                __unsafe_private_start_fn_args: (#(#start_fn_arg_types,)*),
-            }
-        });
+        let start_fn_args_fields_idents = self.start_fn_args().map(|member| &member.ident);
+        let start_fn_args_fields_types = self.start_fn_args().map(|member| &member.ty.norm);
 
         let named_members_types = self.named_members().map(NamedMember::underlying_norm_ty);
 
@@ -104,7 +95,8 @@ impl super::BuilderGenCtx {
                 __unsafe_private_phantom: #phantom_data,
 
                 #receiver_field
-                #start_fn_args_field
+
+                #( #start_fn_args_fields_idents: #start_fn_args_fields_types, )*
 
                 #( #custom_fields_idents: #custom_fields_types, )*
 

--- a/bon-macros/src/builder/builder_gen/builder_derives/debug.rs
+++ b/bon-macros/src/builder/builder_gen/builder_derives/debug.rs
@@ -10,14 +10,14 @@ impl BuilderGenCtx {
         let format_members = self.members.iter().filter_map(|member| {
             match member {
                 Member::StartFn(member) => {
-                    let member_index = &member.index;
-                    let member_ident_str = member.base.ident.to_string();
-                    let member_ty = &member.base.ty.norm;
+                    let member_ident = &member.ident;
+                    let member_ident_str = member_ident.to_string();
+                    let member_ty = &member.ty.norm;
                     Some(quote! {
                         output.field(
                             #member_ident_str,
                             #bon::__::better_errors::as_dyn_debug::<#member_ty>(
-                                &self.__unsafe_private_start_fn_args.#member_index
+                                &self.#member_ident
                             )
                         );
                     })
@@ -57,12 +57,14 @@ impl BuilderGenCtx {
         });
 
         let format_receiver = self.receiver().map(|receiver| {
+            let ident = &receiver.field_ident;
+            let ident_str = ident.to_string();
             let ty = &receiver.without_self_keyword;
             quote! {
                 output.field(
-                    "self",
+                    #ident_str,
                     #bon::__::better_errors::as_dyn_debug::<#ty>(
-                        &self.__unsafe_private_receiver
+                        &self.#ident
                     )
                 );
             }

--- a/bon-macros/src/builder/builder_gen/finish_fn.rs
+++ b/bon-macros/src/builder/builder_gen/finish_fn.rs
@@ -13,9 +13,8 @@ impl super::BuilderGenCtx {
                     .unwrap_or_else(|| quote! { ::core::default::Default::default() });
             }
             Member::StartFn(member) => {
-                let index = &member.index;
-
-                return quote! { self.__unsafe_private_start_fn_args.#index };
+                let ident = &member.ident;
+                return quote! { self.#ident };
             }
             Member::FinishFn(member) => {
                 return member

--- a/bon-macros/src/builder/builder_gen/input_struct.rs
+++ b/bon-macros/src/builder/builder_gen/input_struct.rs
@@ -1,7 +1,7 @@
 use super::models::FinishFnParams;
 use super::top_level_config::TopLevelConfig;
 use super::{
-    AssocMethodCtx, BuilderGenCtx, FinishFnBody, Generics, Member, MemberOrigin, RawMember,
+    AssocMethodCtxParams, BuilderGenCtx, FinishFnBody, Generics, Member, MemberOrigin, RawMember,
 };
 use crate::builder::builder_gen::models::{BuilderGenCtxParams, BuilderTypeParams, StartFnParams};
 use crate::normalization::{GenericsNamespace, SyntaxVariant};
@@ -193,7 +193,7 @@ impl StructInputCtx {
             generics: None,
         };
 
-        let assoc_method_ctx = Some(AssocMethodCtx {
+        let assoc_method_ctx = Some(AssocMethodCtxParams {
             self_ty: self.struct_ty.into(),
             receiver: None,
         });

--- a/bon-macros/src/builder/builder_gen/mod.rs
+++ b/bon-macros/src/builder/builder_gen/mod.rs
@@ -15,10 +15,8 @@ pub(crate) use top_level_config::TopLevelConfig;
 
 use crate::util::prelude::*;
 use getters::GettersCtx;
-use member::{
-    CustomField, Member, MemberOrigin, NamedMember, PosFnMember, RawMember, StartFnMember,
-};
-use models::{AssocMethodCtx, AssocMethodReceiverCtx, BuilderGenCtx, FinishFnBody, Generics};
+use member::{CustomField, Member, MemberOrigin, NamedMember, PosFnMember, RawMember};
+use models::{AssocMethodCtxParams, AssocMethodReceiverCtx, BuilderGenCtx, FinishFnBody, Generics};
 use setters::SettersCtx;
 
 pub(crate) struct MacroOutput {
@@ -39,7 +37,7 @@ impl BuilderGenCtx {
         self.members.iter().filter_map(Member::as_field)
     }
 
-    fn start_fn_args(&self) -> impl Iterator<Item = &StartFnMember> {
+    fn start_fn_args(&self) -> impl Iterator<Item = &PosFnMember> {
         self.members.iter().filter_map(Member::as_start_fn)
     }
 

--- a/bon-macros/src/builder/builder_gen/models.rs
+++ b/bon-macros/src/builder/builder_gen/models.rs
@@ -336,8 +336,10 @@ impl BuilderGenCtx {
                     .map(|member| member.ident.to_string())
                     .collect();
 
-                let field_ident =
-                    crate::normalization::unique_name(&start_fn_arg_names, "receiver".to_owned());
+                let field_ident = crate::normalization::unique_name(
+                    &start_fn_arg_names,
+                    "self_receiver".to_owned(),
+                );
 
                 AssocMethodReceiverCtx {
                     with_self_keyword: receiver.with_self_keyword,

--- a/bon-macros/src/builder/builder_gen/models.rs
+++ b/bon-macros/src/builder/builder_gen/models.rs
@@ -15,6 +15,14 @@ pub(super) trait FinishFnBody {
 pub(super) struct AssocMethodReceiverCtx {
     pub(super) with_self_keyword: syn::Receiver,
     pub(super) without_self_keyword: Box<syn::Type>,
+
+    /// Name of the receiver field in the builder struct.
+    pub(super) field_ident: syn::Ident,
+}
+
+pub(super) struct AssocMethodReceiverCtxParams {
+    pub(super) with_self_keyword: syn::Receiver,
+    pub(super) without_self_keyword: Box<syn::Type>,
 }
 
 pub(super) struct AssocMethodCtx {
@@ -25,6 +33,16 @@ pub(super) struct AssocMethodCtx {
     /// Present only if the method has a receiver, i.e. `self` or `&self` or
     /// `&mut self` or `self: ExplicitType`.
     pub(super) receiver: Option<AssocMethodReceiverCtx>,
+}
+
+pub(super) struct AssocMethodCtxParams {
+    /// The `Self` type of the impl block. It doesn't contain any nested
+    /// `Self` keywords in it. This is prohibited by Rust's syntax itself.
+    pub(super) self_ty: Box<syn::Type>,
+
+    /// Present only if the method has a receiver, i.e. `self` or `&self` or
+    /// `&mut self` or `self: ExplicitType`.
+    pub(super) receiver: Option<AssocMethodReceiverCtxParams>,
 }
 
 pub(super) struct FinishFn {
@@ -175,7 +193,7 @@ pub(super) struct BuilderGenCtxParams<'a> {
     /// Generics to apply to the builder type.
     pub(super) generics: Generics,
 
-    pub(super) assoc_method_ctx: Option<AssocMethodCtx>,
+    pub(super) assoc_method_ctx: Option<AssocMethodCtxParams>,
 
     pub(super) builder_type: BuilderTypeParams,
     pub(super) state_mod: ItemSigConfig,
@@ -309,6 +327,30 @@ impl BuilderGenCtx {
                 .map(|&name| syn::Ident::new(name, Span::call_site()))
                 .unwrap_or_else(|| namespace.unique_ident(format!("{}_", possible_names[0])))
         };
+
+        let assoc_method_ctx = assoc_method_ctx.map(|ctx| {
+            let receiver = ctx.receiver.map(|receiver| {
+                let start_fn_arg_names = members
+                    .iter()
+                    .filter_map(Member::as_start_fn)
+                    .map(|member| member.ident.to_string())
+                    .collect();
+
+                let field_ident =
+                    crate::normalization::unique_name(&start_fn_arg_names, "receiver".to_owned());
+
+                AssocMethodReceiverCtx {
+                    with_self_keyword: receiver.with_self_keyword,
+                    without_self_keyword: receiver.without_self_keyword,
+                    field_ident: syn::Ident::new(&field_ident, Span::call_site()),
+                }
+            });
+
+            AssocMethodCtx {
+                self_ty: ctx.self_ty,
+                receiver,
+            }
+        });
 
         Ok(Self {
             bon: bon.unwrap_or_else(|| syn::parse_quote!(::bon)),

--- a/bon-macros/src/builder/builder_gen/setters/mod.rs
+++ b/bon-macros/src/builder/builder_gen/setters/mod.rs
@@ -349,14 +349,13 @@ impl<'a> SettersCtx<'a> {
                 } else {
                     let builder_ident = &self.base.builder_type.ident;
 
-                    let maybe_receiver_field = self.base.receiver().map(
-                        |_| quote!(__unsafe_private_receiver: self.__unsafe_private_receiver,),
-                    );
+                    let maybe_receiver_field = self.base.receiver().map(|receiver| {
+                        let ident = &receiver.field_ident;
+                        quote!(#ident: self.#ident,)
+                    });
 
-                    let maybe_start_fn_args_field =
-                        self.base.start_fn_args().next().map(
-                            |_| quote!(__unsafe_private_start_fn_args: self.__unsafe_private_start_fn_args,),
-                        );
+                    let start_fn_args_fields_idents =
+                        self.base.start_fn_args().map(|member| &member.ident);
 
                     let custom_fields_idents = self.base.custom_fields().map(|field| &field.ident);
 
@@ -365,7 +364,7 @@ impl<'a> SettersCtx<'a> {
                             __unsafe_private_phantom: ::core::marker::PhantomData,
                             #( #custom_fields_idents: self.#custom_fields_idents, )*
                             #maybe_receiver_field
-                            #maybe_start_fn_args_field
+                            #( #start_fn_args_fields_idents: self.#start_fn_args_fields_idents, )*
                             __unsafe_private_named: self.__unsafe_private_named,
                         }
                     }

--- a/bon-macros/src/normalization/generics_namespace.rs
+++ b/bon-macros/src/normalization/generics_namespace.rs
@@ -33,20 +33,12 @@ impl Visit<'_> for GenericsNamespace {
 
 impl GenericsNamespace {
     pub(crate) fn unique_ident(&self, name: String) -> syn::Ident {
-        let name = Self::unique_name(&self.idents, name);
+        let name = unique_name(&self.idents, name);
         syn::Ident::new(&name, Span::call_site())
     }
 
     pub(crate) fn unique_lifetime(&self, name: String) -> String {
-        Self::unique_name(&self.lifetimes, name)
-    }
-
-    /// Adds `_` suffix to the name to avoid conflicts with existing identifiers.
-    fn unique_name(taken: &BTreeSet<String>, mut ident: String) -> String {
-        while taken.contains(&ident) {
-            ident.push('_');
-        }
-        ident
+        unique_name(&self.lifetimes, name)
     }
 
     pub(crate) fn visit_token_stream(&mut self, token_stream: TokenStream) {
@@ -72,4 +64,12 @@ impl GenericsNamespace {
             }
         }
     }
+}
+
+/// Adds `_` suffix to the name to avoid conflicts with existing identifiers.
+pub(crate) fn unique_name(taken: &BTreeSet<String>, mut ident: String) -> String {
+    while taken.contains(&ident) {
+        ident.push('_');
+    }
+    ident
 }

--- a/bon/tests/integration/builder/attr_derive.rs
+++ b/bon/tests/integration/builder/attr_derive.rs
@@ -88,7 +88,7 @@ fn builder_with_receiver() {
         &actual,
         expect![[r#"
             SutMethodBuilder {
-                receiver: Sut {
+                self_receiver: Sut {
                     name: "Blackjack",
                 },
                 other_name: "P21",
@@ -208,7 +208,7 @@ mod generics {
 
         assert_debug_eq(
             &actual,
-            expect!["SutWithSelfBuilder { receiver: Sut(true), arg1: 42 }"],
+            expect!["SutWithSelfBuilder { self_receiver: Sut(true), arg1: 42 }"],
         );
 
         let actual: u32 = From::from(actual);
@@ -308,13 +308,17 @@ mod positional_members {
 
         assert_debug_eq(
             actual.clone(),
-            expect!["SutWithSelfBuilder { receiver: Sut, start_fn_arg: true }"],
+            expect![[r#"
+                SutWithSelfBuilder {
+                    self_receiver: Sut,
+                    start_fn_arg: true,
+                }"#]],
         );
         assert_debug_eq(
             actual.named(42).clone(),
             expect![[r#"
                 SutWithSelfBuilder {
-                    receiver: Sut,
+                    self_receiver: Sut,
                     start_fn_arg: true,
                     named: 42,
                 }"#]],

--- a/bon/tests/integration/builder/attr_derive.rs
+++ b/bon/tests/integration/builder/attr_derive.rs
@@ -88,7 +88,7 @@ fn builder_with_receiver() {
         &actual,
         expect![[r#"
             SutMethodBuilder {
-                self: Sut {
+                receiver: Sut {
                     name: "Blackjack",
                 },
                 other_name: "P21",
@@ -208,7 +208,7 @@ mod generics {
 
         assert_debug_eq(
             &actual,
-            expect!["SutWithSelfBuilder { self: Sut(true), arg1: 42 }"],
+            expect!["SutWithSelfBuilder { receiver: Sut(true), arg1: 42 }"],
         );
 
         let actual: u32 = From::from(actual);
@@ -308,16 +308,16 @@ mod positional_members {
 
         assert_debug_eq(
             actual.clone(),
-            expect!["SutWithSelfBuilder { self: Sut, start_fn_arg: true }"],
+            expect!["SutWithSelfBuilder { receiver: Sut, start_fn_arg: true }"],
         );
         assert_debug_eq(
             actual.named(42).clone(),
             expect![[r#"
-            SutWithSelfBuilder {
-                self: Sut,
-                start_fn_arg: true,
-                named: 42,
-            }"#]],
+                SutWithSelfBuilder {
+                    receiver: Sut,
+                    start_fn_arg: true,
+                    named: 42,
+                }"#]],
         );
     }
 }

--- a/bon/tests/integration/builder/attr_field.rs
+++ b/bon/tests/integration/builder/attr_field.rs
@@ -162,7 +162,7 @@ fn test_method() {
         &sut,
         expect![[r#"
             SutWithSelfBuilder {
-                receiver: Sut,
+                self_receiver: Sut,
                 x1: 1,
                 x2: 2,
                 x3: false,

--- a/bon/tests/integration/builder/attr_field.rs
+++ b/bon/tests/integration/builder/attr_field.rs
@@ -162,7 +162,7 @@ fn test_method() {
         &sut,
         expect![[r#"
             SutWithSelfBuilder {
-                self: Sut,
+                receiver: Sut,
                 x1: 1,
                 x2: 2,
                 x3: false,

--- a/bon/tests/integration/builder/mod.rs
+++ b/bon/tests/integration/builder/mod.rs
@@ -18,6 +18,7 @@ mod init_order;
 mod lints;
 mod many_params;
 mod name_conflicts;
+mod native_fields;
 mod positional_members;
 mod raw_idents;
 mod smoke;

--- a/bon/tests/integration/builder/native_fields.rs
+++ b/bon/tests/integration/builder/native_fields.rs
@@ -1,0 +1,145 @@
+// Members marked with `#[builder(start_fn)]` should be available as a private fields in the builder.
+mod native_start_fn_fields {
+    use crate::prelude::*;
+
+    #[test]
+    fn test_struct() {
+        #[derive(Builder)]
+        struct Sut {
+            #[builder(start_fn)]
+            #[allow(dead_code)]
+            x1: u32,
+
+            #[builder(start_fn)]
+            #[allow(dead_code)]
+            x2: bool,
+        }
+
+        let builder = Sut::builder(1, true);
+        let x1: &u32 = &builder.x1;
+        let x2: &bool = &builder.x2;
+
+        assert_eq!(*x1, 1);
+        assert!(*x2);
+    }
+
+    #[test]
+    fn test_function() {
+        #[builder]
+        fn sut(#[builder(start_fn)] x1: u32, #[builder(start_fn)] x2: bool) {
+            let _ = x1;
+            let _ = x2;
+        }
+
+        let builder = sut(1, true);
+        let x1: &u32 = &builder.x1;
+        let x2: &bool = &builder.x2;
+
+        assert_eq!(*x1, 1);
+        assert!(*x2);
+    }
+
+    #[test]
+    fn test_method() {
+        struct Sut;
+
+        #[bon]
+        impl Sut {
+            #[builder]
+            fn method(#[builder(start_fn)] x1: u32, #[builder(start_fn)] x2: bool) {
+                let _ = x1;
+                let _ = x2;
+            }
+        }
+
+        let builder = Sut::method(1, true);
+        let x1: &u32 = &builder.x1;
+        let x2: &bool = &builder.x2;
+
+        assert_eq!(*x1, 1);
+        assert!(*x2);
+    }
+}
+
+mod native_receiver_field {
+    use crate::prelude::*;
+
+    // The `self_receiver` field in the builder should be available as a private field in the builder.
+    #[test]
+    fn native_receiver_field_smoke() {
+        struct Sut {
+            x1: u32,
+        }
+
+        #[bon]
+        impl Sut {
+            #[builder]
+            fn method(self) {
+                let _ = self;
+            }
+
+            #[builder]
+            fn method_ref(&self) {
+                let _ = self;
+            }
+
+            #[builder]
+            fn method_mut(&mut self) {
+                self.x1 += 1;
+                let _ = self;
+            }
+        }
+
+        {
+            let builder = Sut { x1: 99 }.method();
+            let receiver: Sut = builder.self_receiver;
+
+            assert_eq!(receiver.x1, 99);
+        }
+
+        {
+            let builder = Sut { x1: 99 }.method_ref();
+            let receiver: &Sut = builder.self_receiver;
+
+            assert_eq!(receiver.x1, 99);
+        }
+
+        {
+            let mut sut = Sut { x1: 99 };
+            let builder = sut.method_mut();
+            let receiver: &mut Sut = builder.self_receiver;
+
+            assert_eq!(receiver.x1, 99);
+        }
+    }
+
+    #[test]
+    fn name_conflict_resolution_for_receiver_field() {
+        struct Sut {
+            x1: u32,
+        }
+
+        #[bon]
+        impl Sut {
+            #[builder]
+            fn method(
+                &self,
+                #[builder(start_fn)] self_receiver: u32,
+                #[builder(start_fn)] self_receiver_: bool,
+            ) {
+                let _ = self_receiver;
+                let _ = self_receiver_;
+                let _ = self;
+            }
+        }
+
+        let builder = Sut { x1: 99 }.method(2, true);
+        let self_receiver: &u32 = &builder.self_receiver;
+        let self_receiver_: &bool = &builder.self_receiver_;
+        let self_receiver__: &Sut = builder.self_receiver__;
+
+        assert_eq!(*self_receiver, 2);
+        assert!(*self_receiver_);
+        assert_eq!(self_receiver__.x1, 99);
+    }
+}

--- a/bon/tests/integration/ui/compile_fail/attr_field.rs
+++ b/bon/tests/integration/ui/compile_fail/attr_field.rs
@@ -6,4 +6,17 @@ struct WrongName {
     __x1: i32,
 }
 
-fn main() {}
+mod privacy {
+    #[derive(bon::Builder)]
+    pub struct MustBePrivate {
+        #[builder(field)]
+        x1: i32,
+    }
+}
+
+fn main() {
+    let builder = privacy::MustBePrivate::builder();
+
+    // Should be inaccessible in this scope
+    let _ = builder.x1;
+}

--- a/bon/tests/integration/ui/compile_fail/attr_field.stderr
+++ b/bon/tests/integration/ui/compile_fail/attr_field.stderr
@@ -3,3 +3,9 @@ error: field names starting with `__` are reserved for `bon`'s internal use; ple
   |
 6 |     __x1: i32,
   |     ^^^^
+
+error[E0616]: field `x1` of struct `MustBePrivateBuilder` is private
+  --> tests/integration/ui/compile_fail/attr_field.rs:21:21
+   |
+21 |     let _ = builder.x1;
+   |                     ^^ private field

--- a/bon/tests/integration/ui/compile_fail/private_fields_access.rs
+++ b/bon/tests/integration/ui/compile_fail/private_fields_access.rs
@@ -17,8 +17,9 @@ fn main() {
     // for details: https://github.com/elastio/bon/issues/218
     let SutSutBuilder {
         __unsafe_private_phantom: _,
-        __unsafe_private_start_fn_args: _,
-        __unsafe_private_receiver: _,
         __unsafe_private_named: _,
+        // These are public
+        _x1: _,
+        receiver: _,
     } = sut;
 }

--- a/bon/tests/integration/ui/compile_fail/private_fields_access.rs
+++ b/bon/tests/integration/ui/compile_fail/private_fields_access.rs
@@ -1,25 +1,43 @@
 #![deny(warnings)]
 
-struct Sut;
+mod unsafe_fields_are_private {
+    struct Sut;
 
-#[bon::bon]
-impl Sut {
-    #[builder]
-    fn sut(self, #[builder(start_fn)] _x1: u32, _x2: u32) {}
+    #[bon::bon]
+    impl Sut {
+        #[builder]
+        fn sut(self, #[builder(start_fn)] _x1: u32, _x2: u32) {}
+    }
+
+    fn _test() {
+        let sut = Sut.sut(99);
+
+        // Previously, there was an attempt to generate names for private fields
+        // with randomness to ensure users don't try to access them. This however,
+        // conflicts with caching in some build systems. See the following issue
+        // for details: https://github.com/elastio/bon/issues/218
+        let SutSutBuilder {
+            __unsafe_private_phantom: _,
+            __unsafe_private_named: _,
+            // These are public
+            _x1: _,
+            self_receiver: _,
+        } = sut;
+    }
+}
+
+mod self_receiver_and_start_fn_args_must_be_private {
+    pub struct MustBePrivate;
+
+    #[bon::bon]
+    impl MustBePrivate {
+        #[builder]
+        pub fn method(self, #[builder(start_fn)] _x1: u32) {}
+    }
 }
 
 fn main() {
-    let sut = Sut.sut(99);
-
-    // Previously, there was an attempt to generate names for private fields
-    // with randomness to ensure users don't try to access them. This however,
-    // conflicts with caching in some build systems. See the following issue
-    // for details: https://github.com/elastio/bon/issues/218
-    let SutSutBuilder {
-        __unsafe_private_phantom: _,
-        __unsafe_private_named: _,
-        // These are public
-        _x1: _,
-        receiver: _,
-    } = sut;
+    let builder = self_receiver_and_start_fn_args_must_be_private::MustBePrivate.method(99);
+    let _ = builder.self_receiver;
+    let _ = builder._x1;
 }

--- a/bon/tests/integration/ui/compile_fail/private_fields_access.stderr
+++ b/bon/tests/integration/ui/compile_fail/private_fields_access.stderr
@@ -11,20 +11,8 @@ note: the lint level is defined here
    |         ^^^^^^^^
    = note: `#[deny(deprecated)]` implied by `#[deny(warnings)]`
 
-error: use of deprecated field `SutSutBuilder::__unsafe_private_start_fn_args`: this field should not be used directly; it's an implementation detail, and if you access it directly, you may break some internal unsafe invariants; if you found yourself needing it, then you are probably doing something wrong; feel free to open an issue/discussion in our GitHub repository (https://github.com/elastio/bon) or ask for help in our Discord server (https://bon-rs.com/discord)
+error: use of deprecated field `SutSutBuilder::__unsafe_private_named`: this field should not be used directly; it's an implementation detail, and if you access it directly, you may break some internal unsafe invariants; if you found yourself needing it, then you are probably doing something wrong; feel free to open an issue/discussion in our GitHub repository (https://github.com/elastio/bon) or ask for help in our Discord server (https://bon-rs.com/discord)
   --> tests/integration/ui/compile_fail/private_fields_access.rs:20:9
    |
-20 |         __unsafe_private_start_fn_args: _,
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: use of deprecated field `SutSutBuilder::__unsafe_private_receiver`: this field should not be used directly; it's an implementation detail, and if you access it directly, you may break some internal unsafe invariants; if you found yourself needing it, then you are probably doing something wrong; feel free to open an issue/discussion in our GitHub repository (https://github.com/elastio/bon) or ask for help in our Discord server (https://bon-rs.com/discord)
-  --> tests/integration/ui/compile_fail/private_fields_access.rs:21:9
-   |
-21 |         __unsafe_private_receiver: _,
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: use of deprecated field `SutSutBuilder::__unsafe_private_named`: this field should not be used directly; it's an implementation detail, and if you access it directly, you may break some internal unsafe invariants; if you found yourself needing it, then you are probably doing something wrong; feel free to open an issue/discussion in our GitHub repository (https://github.com/elastio/bon) or ask for help in our Discord server (https://bon-rs.com/discord)
-  --> tests/integration/ui/compile_fail/private_fields_access.rs:22:9
-   |
-22 |         __unsafe_private_named: _,
+20 |         __unsafe_private_named: _,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/bon/tests/integration/ui/compile_fail/private_fields_access.stderr
+++ b/bon/tests/integration/ui/compile_fail/private_fields_access.stderr
@@ -1,8 +1,8 @@
-error: use of deprecated field `SutSutBuilder::__unsafe_private_phantom`: this field should not be used directly; it's an implementation detail, and if you access it directly, you may break some internal unsafe invariants; if you found yourself needing it, then you are probably doing something wrong; feel free to open an issue/discussion in our GitHub repository (https://github.com/elastio/bon) or ask for help in our Discord server (https://bon-rs.com/discord)
-  --> tests/integration/ui/compile_fail/private_fields_access.rs:19:9
+error: use of deprecated field `unsafe_fields_are_private::SutSutBuilder::__unsafe_private_phantom`: this field should not be used directly; it's an implementation detail, and if you access it directly, you may break some internal unsafe invariants; if you found yourself needing it, then you are probably doing something wrong; feel free to open an issue/discussion in our GitHub repository (https://github.com/elastio/bon) or ask for help in our Discord server (https://bon-rs.com/discord)
+  --> tests/integration/ui/compile_fail/private_fields_access.rs:20:13
    |
-19 |         __unsafe_private_phantom: _,
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+20 |             __unsafe_private_phantom: _,
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
   --> tests/integration/ui/compile_fail/private_fields_access.rs:1:9
@@ -11,8 +11,20 @@ note: the lint level is defined here
    |         ^^^^^^^^
    = note: `#[deny(deprecated)]` implied by `#[deny(warnings)]`
 
-error: use of deprecated field `SutSutBuilder::__unsafe_private_named`: this field should not be used directly; it's an implementation detail, and if you access it directly, you may break some internal unsafe invariants; if you found yourself needing it, then you are probably doing something wrong; feel free to open an issue/discussion in our GitHub repository (https://github.com/elastio/bon) or ask for help in our Discord server (https://bon-rs.com/discord)
-  --> tests/integration/ui/compile_fail/private_fields_access.rs:20:9
+error: use of deprecated field `unsafe_fields_are_private::SutSutBuilder::__unsafe_private_named`: this field should not be used directly; it's an implementation detail, and if you access it directly, you may break some internal unsafe invariants; if you found yourself needing it, then you are probably doing something wrong; feel free to open an issue/discussion in our GitHub repository (https://github.com/elastio/bon) or ask for help in our Discord server (https://bon-rs.com/discord)
+  --> tests/integration/ui/compile_fail/private_fields_access.rs:21:13
    |
-20 |         __unsafe_private_named: _,
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+21 |             __unsafe_private_named: _,
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0616]: field `self_receiver` of struct `MustBePrivateMethodBuilder` is private
+  --> tests/integration/ui/compile_fail/private_fields_access.rs:41:21
+   |
+41 |     let _ = builder.self_receiver;
+   |                     ^^^^^^^^^^^^^ private field
+
+error[E0616]: field `_x1` of struct `MustBePrivateMethodBuilder` is private
+  --> tests/integration/ui/compile_fail/private_fields_access.rs:42:21
+   |
+42 |     let _ = builder._x1;
+   |                     ^^^ private field

--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -186,8 +186,8 @@ export default defineConfig({
                             link: "/guide/typestate-api/custom-methods",
                         },
                         {
-                            text: "Custom Fields",
-                            link: "/guide/typestate-api/custom-fields",
+                            text: "Builder Fields",
+                            link: "/guide/typestate-api/builder-fields",
                         },
                         {
                             text: "Getters 🔬",

--- a/website/src/guide/alternatives.md
+++ b/website/src/guide/alternatives.md
@@ -201,7 +201,7 @@ Why is there an explicit `main()` function in this code snippet 🤔? It's a lon
 
 :::
 
-It is possible to implement this with `bon` using custom fields and custom setters. See an example of how this can be done [here](../guide/typestate-api/custom-fields).
+It is possible to implement this with `bon` using custom fields and custom setters. See an example of how this can be done [here](../guide/typestate-api/builder-fields).
 
 Alternatively, `bon` provides a separate solution. `bon` exposes the following macros that provide convenient syntax to create collections.
 

--- a/website/src/guide/typestate-api/builder-fields.md
+++ b/website/src/guide/typestate-api/builder-fields.md
@@ -4,13 +4,13 @@ On this page, you'll learn how to access some [native fields](#native-fields) of
 
 ## Native Fields
 
-There are some native module-private fields on the builder that _you can access_ as the user of `bon`'s builder macros. The fields described below are guaranteed to have stable names and types so that you could use them in your custom methods such as custom setters and getters.
+There are some native module-private fields on the builder that _you can access_ as the user of `bon`'s builder macros. The fields described below are guaranteed to have stable names and types so you can use them in custom methods such as custom setters and getters.
 
 ::: warning Important Privacy Clarification
 
 The native fields documented here have default private Rust visibility. They are declared like this in the builder struct:
 
-```rust
+```rust compile_fail
 struct BuilderStruct {
     self_receiver: T,
     // ... other not documented fields are actually private impl. details,

--- a/website/src/guide/typestate-api/builder-fields.md
+++ b/website/src/guide/typestate-api/builder-fields.md
@@ -1,6 +1,83 @@
-# Custom Fields
+# Builder Fields
 
-On this page, you'll learn how to add custom fields to the builder type 🌾.
+On this page, you'll learn how to access some [native fields](#native-fields) of the builder type and add [custom fields](#custom-fields) to it 🌾.
+
+## Native Fields
+
+There are some native module-private fields on the builder that _you can access_ as the user of `bon`'s builder macros. The fields described below are guaranteed to have stable names and types so that you could use them in your custom methods such as custom setters and getters.
+
+::: warning Important Privacy Clarification
+
+The native fields documented here have default private Rust visibility. They are declared like this in the builder struct:
+
+```rust
+struct BuilderStruct {
+    self_receiver: T,
+    // ... other not documented fields are actually private impl. details,
+    // so don't even try to access fields that begin with `__unsafe_private`!
+}
+```
+
+This means the fields documented below are accessible within the module where the builder struct was generated, but if you try to access them outside this module's scope, you'll get a compile error, because the fields aren't marked as `pub` or `pub(...)`.
+
+:::
+
+### `self_receiver`
+
+The field `self_receiver` is available on a builder generated from a method that has a `self` parameter.
+
+::: tip
+
+The term "receiver" was borrowed from [`syn`'s](https://docs.rs/syn/latest/syn/struct.Receiver.html) and [Rust Reference](https://doc.rust-lang.org/reference/expressions/method-call-expr.html) terminology.
+
+:::
+
+```rust
+use bon::bon;
+
+struct Example {
+    x1: u32
+}
+
+#[bon]
+impl Example {
+    #[builder]
+    fn method(&self) {
+        // ...
+    }
+}
+
+let builder = Example { x1: 99 }.method();
+
+// We can access the `self_receiver` on the builder. // [!code highlight]
+// It is a reference in this case, because `method` takes a `&self` // [!code highlight]
+let self_receiver: &Example = builder.self_receiver;
+
+assert_eq!(self_receiver.x1, 99);
+```
+
+### `#[builder(start_fn)]` members
+
+You can access the values of members marked with [`#[builder(start_fn)]`](../../reference/builder/member/start_fn) by their name on the builder directly.
+
+```rust
+use bon::Builder;
+
+#[derive(Builder)]
+struct Example {
+    #[builder(start_fn)]
+    x1: u32
+}
+
+let builder = Example::builder(99);
+
+// We can access the `x1` on the builder directly. // [!code highlight]
+let x1: u32 = builder.x1;
+
+assert_eq!(x1, 99);
+```
+
+## Custom Fields
 
 This is useful if you'd like a completely custom state for [custom setters](./custom-methods) in the builder.
 

--- a/website/src/guide/typestate-api/getters.md
+++ b/website/src/guide/typestate-api/getters.md
@@ -2,6 +2,8 @@
 
 You can generate a getter method for the member with the experimental attribute [`#[builder(getter)]`](../../reference/builder/member/getter) 🔬. The generated getter is available only when the value for the member was set (i.e. its type state implements the [`IsSet`](./custom-methods#isset-trait) trait).
 
+## Custom Getters
+
 You can define a custom getter method on the builder, that adds some custom logic on top of just getting a value. To do that, generate an "internal" getter with private visibility under a different name and define your own getter that uses it in an impl block.
 
 ```rust
@@ -29,3 +31,5 @@ let builder = Example::builder().x(3);
 
 assert_eq!(builder.get_x(), 6);
 ```
+
+You can also create custom getters for builder's [native fields](./builder-fields#native-fields), which are module-private by default.

--- a/website/src/reference/builder/top-level/derive.md
+++ b/website/src/reference/builder/top-level/derive.md
@@ -128,10 +128,10 @@ let example: u32 = builder
 assert_eq!(example, 99);
 
 // The debug output of the builder for methods with `self` includes
-// the special field with called `receiver` that stores the `self` value.
+// the special field with called `self_receiver` that stores the `self` value.
 assert_eq!(
     format!("{:?}", Example.method_with_self()),
-    "ExampleMethodWithSelfBuilder { receiver: Example }"
+    "ExampleMethodWithSelfBuilder { self_receiver: Example }"
 )
 ```
 

--- a/website/src/reference/builder/top-level/derive.md
+++ b/website/src/reference/builder/top-level/derive.md
@@ -128,10 +128,10 @@ let example: u32 = builder
 assert_eq!(example, 99);
 
 // The debug output of the builder for methods with `self` includes
-// the special `self` field with the receiver.
+// the special field with called `receiver` that stores the `self` value.
 assert_eq!(
     format!("{:?}", Example.method_with_self()),
-    "ExampleMethodWithSelfBuilder { self: Example }"
+    "ExampleMethodWithSelfBuilder { receiver: Example }"
 )
 ```
 


### PR DESCRIPTION
This is according to my design decision here: https://github.com/elastio/bon/issues/225#issuecomment-2526318087