### PR TITLE
Stabilize the current `#[builder(getter)]` feature MVP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,19 +112,19 @@ jobs:
       - run: cargo test --locked --all-features --doc
       - run: |
           cd bon && cargo test --locked --no-default-features \
-            --features=experimental-overwritable,experimental-getter
+            --features=experimental-overwritable
 
       - run: |
           cd bon && cargo test --locked --no-default-features \
-            --features=experimental-overwritable,experimental-getter,alloc
+            --features=experimental-overwritable,alloc
 
       - run: |
           cd bon && cargo test --locked --no-default-features \
-            --features=experimental-overwritable,experimental-getter,implied-bounds
+            --features=experimental-overwritable,implied-bounds
 
       - run: |
           cd bon && cargo test --locked --no-default-features \
-            --features=experimental-overwritable,experimental-getter,alloc,implied-bounds
+            --features=experimental-overwritable,alloc,implied-bounds
 
   test-msrv:
     runs-on: ${{ matrix.os }}-latest

--- a/bon-macros/Cargo.toml
+++ b/bon-macros/Cargo.toml
@@ -63,9 +63,6 @@ rustversion  = "1.0"
 [features]
 default = []
 
-# See the docs on this feature in the `bon`'s crate `Cargo.toml`.
-experimental-getter = []
-
 # See the docs on this feature in the `bon`'s crate `Cargo.toml`
 experimental-overwritable = []
 

--- a/bon-macros/src/builder/builder_gen/member/config/mod.rs
+++ b/bon-macros/src/builder/builder_gen/member/config/mod.rs
@@ -223,18 +223,6 @@ impl MemberConfig {
         }
 
         if let Some(getter) = &self.getter {
-            if !cfg!(feature = "experimental-getter") {
-                bail!(
-                    &getter.key,
-                    "🔬 `getter` attribute is experimental and requires \
-                    \"experimental-getter\" cargo feature to be enabled; \
-                    if you find the current design of this attribute already \
-                    solid please leave a 👍 reaction under the issue \
-                    https://github.com/elastio/bon/issues/225; if you have \
-                    any feedback, then feel free to leave a comment under that issue",
-                );
-            }
-
             self.validate_mutually_exclusive(
                 ParamName::Getter,
                 getter.key.span(),

--- a/bon-sandbox/Cargo.toml
+++ b/bon-sandbox/Cargo.toml
@@ -34,6 +34,6 @@ derive_builder = "0.20"
 typed-builder  = "0.20"
 
 [dependencies.bon]
-features = ["experimental-overwritable", "experimental-getter"]
+features = ["experimental-overwritable"]
 path     = "../bon"
 version  = "=3.3.2"

--- a/bon/Cargo.toml
+++ b/bon/Cargo.toml
@@ -83,15 +83,9 @@ implied-bounds = ["bon-macros/implied-bounds"]
 # describing your use case for it.
 experimental-overwritable = ["bon-macros/experimental-overwritable"]
 
-# 🔬 Experimental! There may be breaking changes to this feature between *minor* releases,
-# however, compatibility within patch releases is guaranteed though.
+# Legacy experimental attribute. It's left here for backwards compatibility,
+# and it will be removed in the next major release.
 #
-# This feature enables the #[builder(getter)] attribute that can be used to
-# allow getting references to already set fields in the builder.
-#
-# See more info at https://bon-rs.com/reference/builder/member/getter.
-#
-# The fate of this feature depends on your feedback in the tracking issue
-# https://github.com/elastio/bon/issues/225. Please, let us know if you
-# have any ideas how to make this attribute better, or if it's already good enough!
-experimental-getter = ["bon-macros/experimental-getter"]
+# We've stabilized the MVP of this feature, so it's no longer experimental.
+# The tracking issue for this feature: https://github.com/elastio/bon/issues/225.
+experimental-getter = []

--- a/scripts/test-msrv.sh
+++ b/scripts/test-msrv.sh
@@ -40,7 +40,7 @@ step cargo update -p libc --precise 0.2.163
 
 export RUSTFLAGS="${RUSTFLAGS:-} --allow unknown-lints"
 
-features=experimental-overwritable,experimental-getter
+features=experimental-overwritable
 
 step cargo clippy --all-targets --locked --features "$features"
 

--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -190,7 +190,7 @@ export default defineConfig({
                             link: "/guide/typestate-api/builder-fields",
                         },
                         {
-                            text: "Getters 🔬",
+                            text: "Getters",
                             link: "/guide/typestate-api/getters",
                         },
                     ],
@@ -308,7 +308,7 @@ export default defineConfig({
                                     link: "/reference/builder/member/finish_fn",
                                 },
                                 {
-                                    text: "getter 🔬",
+                                    text: "getter",
                                     link: "/reference/builder/member/getter",
                                 },
                                 {

--- a/website/src/guide/typestate-api/getters.md
+++ b/website/src/guide/typestate-api/getters.md
@@ -1,6 +1,6 @@
-# Getters :microscope:
+# Getters
 
-You can generate a getter method for the member with the experimental attribute [`#[builder(getter)]`](../../reference/builder/member/getter) 🔬. The generated getter is available only when the value for the member was set (i.e. its type state implements the [`IsSet`](./custom-methods#isset-trait) trait).
+You can generate a getter method for the member with the attribute [`#[builder(getter)]`](../../reference/builder/member/getter). The generated getter is available only when the value for the member was set (i.e. its type state implements the [`IsSet`](./custom-methods#isset-trait) trait).
 
 ## Custom Getters
 

--- a/website/src/reference/builder.md
+++ b/website/src/reference/builder.md
@@ -25,7 +25,7 @@ These attributes are placed on a `struct` field or `fn` argument.
 | [`default`](./builder/member/default)              | Makes the member optional with a default value                   |
 | [`field`](./builder/member/field)                  | Defines a private field on the builder without setters           |
 | [`finish_fn`](./builder/member/finish_fn)          | Makes the member a positional argument on the finishing function |
-| [`getter` 🔬](./builder/member/getter)             | Generates a getter method for a member                           |
+| [`getter`](./builder/member/getter)                | Generates a getter method for a member                           |
 | [`into`](./builder/member/into)                    | Changes the signature of the setters to accept `impl Into<T>`    |
 | [`name`](./builder/member/name)                    | Overrides the name of the member used in the builder's API       |
 | [`overwritable` 🔬](./builder/member/overwritable) | Allows calling setters for the same member repeatedly            |

--- a/website/src/reference/builder/member/getter.md
+++ b/website/src/reference/builder/member/getter.md
@@ -1,16 +1,12 @@
-# `getter` :microscope:
+# `getter`
 
 **Applies to:** <Badge type="warning" text="struct fields"/> <Badge type="warning" text="function arguments"/> <Badge type="warning" text="method arguments"/>
 
 Generates a getter method for a member. The method is callable only after the value for the member is set using any of its setters.
 
-::: danger 🔬 **Experimental**
+> This attribute has some planned future extensions described in the tracking issue [#225](https://github.com/elastio/bon/issues/225). Any feedback is appreciated!
 
-This attribute is available under the cargo feature `experimental-getter`. Breaking changes may occur between **minor** releases but not between patch releases.
-
-The fate of this feature depends on your feedback in the tracking issue [#225](https://github.com/elastio/bon/issues/225). Please, let us know if you have any ideas on improving this attribute, or if it's already good enough!
-
-:::
+---
 
 The getter for a required member returns `&T` by default (can be [overridden](#overriding-the-return-type)).
 
@@ -119,7 +115,7 @@ You can override the return type of the getter, its name, visibility, and docs.
         deref,
 
         // Return the type specified in parens.
-        // A deref coercion is expected to be valid to the specified type.
+        // There must exist a deref coercion is to the specified type.
         // Don't specify the leading `&` here.
         deref(T),
 

--- a/website/src/reference/builder/member/getter.md
+++ b/website/src/reference/builder/member/getter.md
@@ -115,7 +115,7 @@ You can override the return type of the getter, its name, visibility, and docs.
         deref,
 
         // Return the type specified in parens.
-        // There must exist a deref coercion is to the specified type.
+        // There must exist a deref coercion to the specified type.
         // Don't specify the leading `&` here.
         deref(T),
 


### PR DESCRIPTION
It's been ~3 months since we've introduced an MVP of the `#[builder(getter)]` attribute, and the feature hasn't changed since its initial design. There are already some people using this API and asking to get it stabilized.

I believe the current API design is already firm, and still amenable to the future extensions described in https://github.com/elastio/bon/issues/225, so let's deploy this 🚀 