### PR TITLE
Delay the renaming of the original function to `__orig_{fn_name}` until after all other macros are expanded

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,9 +71,9 @@ version = "3.5.0"
 dependencies = [
  "bon-macros",
  "expect-test",
+ "macro_rules_attribute",
  "rustversion",
  "tokio",
- "tracing",
  "trybuild",
 ]
 

--- a/bon-macros/src/builder/builder_gen/input_fn/validation.rs
+++ b/bon-macros/src/builder/builder_gen/input_fn/validation.rs
@@ -1,5 +1,4 @@
 use crate::util::prelude::*;
-use syn::spanned::Spanned;
 use syn::visit::Visit;
 
 impl super::FnInputCtx<'_> {
@@ -32,31 +31,13 @@ impl super::FnInputCtx<'_> {
     }
 
     pub(crate) fn warnings(&self) -> TokenStream {
-        let mut warnings = TokenStream::new();
+        // We used to emit some warnings here previously, but then that logic
+        // was removed. The code for the `warnings()` method was preserved just
+        // in case if we need to issue some new warnings again. However, it's not
+        // critical. Feel free to eliminate this method if you feel like it.
+        let _ = self;
 
-        let bon = self
-            .config
-            .bon
-            .clone()
-            .unwrap_or_else(|| syn::parse_quote!(::bon));
-
-        let instrument = self
-            .fn_item
-            .orig
-            .attrs
-            .iter()
-            .filter_map(|attr| attr.path().segments.last())
-            .find(|segment| segment.ident == "instrument");
-
-        if let Some(instrument) = instrument {
-            let span = instrument.span();
-
-            warnings.extend(quote_spanned! {span=>
-                use #bon::__::warnings::tracing_instrument_attribute_after_builder as _;
-            });
-        }
-
-        warnings
+        TokenStream::new()
     }
 }
 

--- a/bon-macros/src/builder/builder_gen/models.rs
+++ b/bon-macros/src/builder/builder_gen/models.rs
@@ -1,7 +1,7 @@
 use super::member::Member;
 use super::top_level_config::{DerivesConfig, OnConfig};
 use crate::normalization::GenericsNamespace;
-use crate::parsing::{ItemSigConfig, SpannedKey};
+use crate::parsing::{BonCratePath, ItemSigConfig, SpannedKey};
 use crate::util::prelude::*;
 use std::borrow::Cow;
 
@@ -150,8 +150,7 @@ pub(super) struct Generics {
 }
 
 pub(crate) struct BuilderGenCtx {
-    /// Path to the `bon` crate.
-    pub(super) bon: syn::Path,
+    pub(super) bon: BonCratePath,
 
     /// Name of the generic variable that holds the builder's state.
     pub(super) state_var: syn::Ident,
@@ -175,7 +174,7 @@ pub(crate) struct BuilderGenCtx {
 }
 
 pub(super) struct BuilderGenCtxParams<'a> {
-    pub(crate) bon: Option<syn::Path>,
+    pub(crate) bon: BonCratePath,
     pub(super) namespace: Cow<'a, GenericsNamespace>,
     pub(super) members: Vec<Member>,
 
@@ -355,7 +354,7 @@ impl BuilderGenCtx {
         });
 
         Ok(Self {
-            bon: bon.unwrap_or_else(|| syn::parse_quote!(::bon)),
+            bon,
             state_var,
             members,
             allow_attrs,

--- a/bon-macros/src/builder/builder_gen/top_level_config/mod.rs
+++ b/bon-macros/src/builder/builder_gen/top_level_config/mod.rs
@@ -2,7 +2,7 @@ mod on;
 
 pub(crate) use on::OnConfig;
 
-use crate::parsing::{ItemSigConfig, ItemSigConfigParsing, SpannedKey};
+use crate::parsing::{BonCratePath, ItemSigConfig, ItemSigConfigParsing, SpannedKey};
 use crate::util::prelude::*;
 use darling::ast::NestedMeta;
 use darling::FromMeta;
@@ -45,8 +45,8 @@ fn parse_start_fn(meta: &syn::Meta) -> Result<ItemSigConfig> {
 pub(crate) struct TopLevelConfig {
     /// Overrides the path to the `bon` crate. This is useful when the macro is
     /// wrapped in another macro that also reexports `bon`.
-    #[darling(rename = "crate", default, map = Some, with = crate::parsing::parse_bon_crate_path)]
-    pub(crate) bon: Option<syn::Path>,
+    #[darling(rename = "crate", default)]
+    pub(crate) bon: BonCratePath,
 
     #[darling(default, with = parse_start_fn)]
     pub(crate) start_fn: ItemSigConfig,

--- a/bon-macros/src/builder/item_impl.rs
+++ b/bon-macros/src/builder/item_impl.rs
@@ -1,6 +1,7 @@
 use super::builder_gen::input_fn::{FnInputCtx, FnInputCtxParams, ImplCtx};
 use super::builder_gen::TopLevelConfig;
 use crate::normalization::{GenericsNamespace, SyntaxVariant};
+use crate::parsing::BonCratePath;
 use crate::util::prelude::*;
 use darling::FromMeta;
 use std::rc::Rc;
@@ -11,8 +12,8 @@ use syn::visit_mut::VisitMut;
 pub(crate) struct ImplInputParams {
     /// Overrides the path to the `bon` crate. This is useful when the macro is
     /// wrapped in another macro that also reexports `bon`.
-    #[darling(rename = "crate", default, map = Some, with = crate::parsing::parse_bon_crate_path)]
-    bon: Option<syn::Path>,
+    #[darling(rename = "crate", default)]
+    bon: BonCratePath,
 }
 
 // ImplInputParams will evolve in the future where we'll probably want to move from it
@@ -111,9 +112,9 @@ pub(crate) fn generate(
 
             let mut config = TopLevelConfig::parse_for_fn(&orig_fn, None)?;
 
-            if let Some(bon) = config.bon {
+            if let BonCratePath::Explicit(path) = config.bon {
                 bail!(
-                    &bon,
+                    &path,
                     "`crate` parameter should be specified via `#[bon(crate = path::to::bon)]` \
                     when impl block syntax is used; no need to specify it in the method's \
                     `#[builder]` attribute"

--- a/bon-macros/src/lib.rs
+++ b/bon-macros/src/lib.rs
@@ -24,6 +24,7 @@ mod collections;
 mod error;
 mod normalization;
 mod parsing;
+mod privatize;
 mod util;
 
 #[cfg(test)]
@@ -308,4 +309,15 @@ pub fn set(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let entries = syn::parse_macro_input!(input with Punctuated::parse_terminated);
 
     collections::set::generate(entries).into()
+}
+
+// Private implementation detail. Don't use it directly!
+// This attribute renames the function provided to it to `__orig_{fn_name}`
+#[doc(hidden)]
+#[proc_macro_attribute]
+pub fn __privatize(
+    _params: proc_macro::TokenStream,
+    input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    privatize::privatize_fn(input.into()).into()
 }

--- a/bon-macros/src/parsing/bon_crate_path.rs
+++ b/bon-macros/src/parsing/bon_crate_path.rs
@@ -1,0 +1,60 @@
+use crate::util::prelude::*;
+use darling::FromMeta;
+
+#[derive(Debug, Clone)]
+pub(crate) enum BonCratePath {
+    Default,
+    Explicit(syn::Path),
+}
+
+impl Default for BonCratePath {
+    fn default() -> Self {
+        Self::Default
+    }
+}
+
+impl FromMeta for BonCratePath {
+    fn from_meta(meta: &syn::Meta) -> Result<Self> {
+        let path = super::parse_path_mod_style(meta)?;
+
+        let prefix = &path
+            .segments
+            .first()
+            .ok_or_else(|| err!(&path, "path must have at least one segment"))?
+            .ident;
+
+        let is_absolute = path.leading_colon.is_some() || prefix == "crate" || prefix == "$crate";
+
+        if is_absolute {
+            return Ok(Self::Explicit(path));
+        }
+
+        if prefix == "super" || prefix == "self" {
+            bail!(
+                &path,
+                "path must not be relative; specify the path that starts with `crate::` \
+                instead; if you want to refer to a reexport from an external crate then \
+                use leading colons like `::crate_name::reexport::path::bon`"
+            )
+        }
+
+        let path_str = darling::util::path_to_string(&path);
+
+        bail!(
+            &path,
+            "path must be absolute; if you want to refer to a reexport from an external \
+            crate then add leading colons like `::{path_str}`; if the path leads to a module \
+            in the current crate, then specify the absolute path with `crate` like \
+            `crate::reexport::path::bon` or `$crate::reexport::path::bon` (if within a macro)"
+        );
+    }
+}
+
+impl ToTokens for BonCratePath {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match self {
+            Self::Default => tokens.extend(quote!(::bon)),
+            Self::Explicit(path) => path.to_tokens(tokens),
+        }
+    }
+}

--- a/bon-macros/src/parsing/mod.rs
+++ b/bon-macros/src/parsing/mod.rs
@@ -1,8 +1,10 @@
+mod bon_crate_path;
 mod docs;
 mod item_sig;
 mod simple_closure;
 mod spanned_key;
 
+pub(crate) use bon_crate_path::*;
 pub(crate) use docs::*;
 pub(crate) use item_sig::*;
 pub(crate) use simple_closure::*;
@@ -89,41 +91,6 @@ fn parse_path_mod_style(meta: &syn::Meta) -> Result<syn::Path> {
     };
 
     Ok(expr.require_path_mod_style()?.clone())
-}
-
-pub(crate) fn parse_bon_crate_path(meta: &syn::Meta) -> Result<syn::Path> {
-    let path = parse_path_mod_style(meta)?;
-
-    let prefix = &path
-        .segments
-        .first()
-        .ok_or_else(|| err!(&path, "path must have at least one segment"))?
-        .ident;
-
-    let is_absolute = path.leading_colon.is_some() || prefix == "crate" || prefix == "$crate";
-
-    if is_absolute {
-        return Ok(path);
-    }
-
-    if prefix == "super" || prefix == "self" {
-        bail!(
-            &path,
-            "path must not be relative; specify the path that starts with `crate::` \
-            instead; if you want to refer to a reexport from an external crate then \
-            use a leading colon like `::crate_name::reexport::path::bon`"
-        )
-    }
-
-    let path_str = darling::util::path_to_string(&path);
-
-    bail!(
-        &path,
-        "path must be absolute; if you want to refer to a reexport from an external \
-        crate then add a leading colon like `::{path_str}`; if the path leads to a module \
-        in the current crate, then specify the absolute path with `crate` like \
-        `crate::reexport::path::bon` or `$crate::reexport::path::bon` (if within a macro)"
-    )
 }
 
 // Lint from nightly. `&Option<T>` is used to reduce syntax at the callsite

--- a/bon-macros/src/privatize.rs
+++ b/bon-macros/src/privatize.rs
@@ -1,0 +1,29 @@
+use crate::util::prelude::*;
+use syn::parse::{ParseStream, Parser};
+
+pub(crate) fn privatize_fn(input: TokenStream) -> TokenStream {
+    transform
+        .parse2(input)
+        .unwrap_or_else(syn::Error::into_compile_error)
+}
+
+fn transform(input: ParseStream<'_>) -> syn::Result<TokenStream> {
+    let outer_attrs = syn::Attribute::parse_outer(input)?;
+    let vis: syn::Visibility = input.parse()?;
+
+    let mut sig: syn::Signature = input.parse()?;
+    privatize_fn_name(&mut sig);
+
+    let rest: TokenStream = input.parse()?;
+
+    Ok(quote::quote! {
+        #(#outer_attrs)* #vis #sig #rest
+    })
+}
+
+pub(crate) fn privatize_fn_name(sig: &mut syn::Signature) {
+    // We don't generate a random name to ensure reproducible builds. Some of
+    // `bon`'s users use custom build systems where the output of the macro is
+    // cached and the stability of the output is depended upon.
+    sig.ident = quote::format_ident!("__orig_{}", sig.ident.raw_name());
+}

--- a/bon/Cargo.toml
+++ b/bon/Cargo.toml
@@ -53,8 +53,9 @@ rustversion = "1"
 expect-test = "1.4.1"
 
 # Using a bit older version that supports our MSRV
-tokio   = { version = "1.29.1", features = ["macros", "rt-multi-thread"] }
-tracing = "0.1"
+tokio = { version = "1.29.1", features = ["macros", "rt-multi-thread"] }
+
+macro_rules_attribute = "0.2"
 
 # Using a bit older version that supports our MSRV
 trybuild = "1.0.89"

--- a/bon/src/__/mod.rs
+++ b/bon/src/__/mod.rs
@@ -14,8 +14,6 @@ pub mod ide;
 
 pub mod better_errors;
 
-pub mod warnings;
-
 mod cfg_eval;
 
 // This reexport is a private implementation detail and should not be used
@@ -23,6 +21,7 @@ mod cfg_eval;
 // patch releases. Use the export from your generated  builder's state module
 // directly instead of using this reexport from `bon::__`.
 pub use crate::builder_state::{IsSet, IsUnset};
+pub use bon_macros::__privatize;
 pub use rustversion;
 
 pub(crate) mod sealed {

--- a/bon/src/__/warnings.rs
+++ b/bon/src/__/warnings.rs
@@ -1,9 +1,0 @@
-#[doc(hidden)]
-#[deprecated(note = "\
-    #[tracing::instrument] attribute should be placed before the #[builder] attribute \
-    to make sure it uses the original function name as the span name;\n\n\
-    reason: when the #[tracing::instrument] attribute is placed after the #[builder] \
-    attribute it will run after the #[builder] attribute is expanded, at which point \
-    the original function will be renamed to __orig_{fn_name}, and this will make \
-    that extra __orig_ prefix appear in the span name, which is likely not what you want")]
-pub mod tracing_instrument_attribute_after_builder {}

--- a/bon/tests/integration/builder/mod.rs
+++ b/bon/tests/integration/builder/mod.rs
@@ -20,6 +20,7 @@ mod lints;
 mod many_params;
 mod name_conflicts;
 mod native_fields;
+mod orig_fn_naming;
 mod positional_members;
 mod raw_idents;
 mod smoke;

--- a/bon/tests/integration/builder/orig_fn_naming.rs
+++ b/bon/tests/integration/builder/orig_fn_naming.rs
@@ -10,18 +10,18 @@ fn attributes_see_orig_fn_name() {
         ) => {
             $(#[$attr])*
             fn $fn_name() -> $ret {
-                stringify!($fn_name).to_string()
+                stringify!($fn_name)
             }
         };
     }
 
     #[builder]
     #[apply(return_fn_name!)]
-    fn attr_after_builder() -> String {}
+    fn attr_after_builder() -> &'static str {}
 
     #[apply(return_fn_name!)]
     #[builder]
-    fn attr_before_builder() -> String {}
+    fn attr_before_builder() -> &'static str {}
 
     struct Sut;
 
@@ -29,30 +29,30 @@ fn attributes_see_orig_fn_name() {
     impl Sut {
         #[builder]
         #[apply(return_fn_name!)]
-        fn attr_after_builder() -> String {}
+        fn attr_after_builder() -> &'static str {}
 
         #[apply(return_fn_name!)]
         #[builder]
-        fn attr_before_builder() -> String {}
+        fn attr_before_builder() -> &'static str {}
     }
 
     let actual = attr_after_builder().call();
     let expected = expect!["attr_after_builder"];
 
-    expected.assert_eq(&actual);
+    expected.assert_eq(actual);
 
     let actual = attr_before_builder().call();
     let expected = expect!["attr_before_builder"];
 
-    expected.assert_eq(&actual);
+    expected.assert_eq(actual);
 
     let actual = Sut::attr_after_builder().call();
     let expected = expect!["attr_after_builder"];
 
-    expected.assert_eq(&actual);
+    expected.assert_eq(actual);
 
     let actual = Sut::attr_before_builder().call();
     let expected = expect!["attr_before_builder"];
 
-    expected.assert_eq(&actual);
+    expected.assert_eq(actual);
 }

--- a/bon/tests/integration/builder/orig_fn_naming.rs
+++ b/bon/tests/integration/builder/orig_fn_naming.rs
@@ -1,0 +1,58 @@
+use crate::prelude::*;
+use macro_rules_attribute::apply;
+
+#[test]
+fn attributes_see_orig_fn_name() {
+    macro_rules! return_fn_name {
+        (
+            $(#[$attr:meta])*
+            fn $fn_name:ident() -> $ret:ty {}
+        ) => {
+            $(#[$attr])*
+            fn $fn_name() -> $ret {
+                stringify!($fn_name).to_string()
+            }
+        };
+    }
+
+    #[builder]
+    #[apply(return_fn_name!)]
+    fn attr_after_builder() -> String {}
+
+    #[apply(return_fn_name!)]
+    #[builder]
+    fn attr_before_builder() -> String {}
+
+    struct Sut;
+
+    #[bon]
+    impl Sut {
+        #[builder]
+        #[apply(return_fn_name!)]
+        fn attr_after_builder() -> String {}
+
+        #[apply(return_fn_name!)]
+        #[builder]
+        fn attr_before_builder() -> String {}
+    }
+
+    let actual = attr_after_builder().call();
+    let expected = expect!["attr_after_builder"];
+
+    expected.assert_eq(&actual);
+
+    let actual = attr_before_builder().call();
+    let expected = expect!["attr_before_builder"];
+
+    expected.assert_eq(&actual);
+
+    let actual = Sut::attr_after_builder().call();
+    let expected = expect!["attr_after_builder"];
+
+    expected.assert_eq(&actual);
+
+    let actual = Sut::attr_before_builder().call();
+    let expected = expect!["attr_before_builder"];
+
+    expected.assert_eq(&actual);
+}

--- a/bon/tests/integration/ui/compile_fail/attr_crate.stderr
+++ b/bon/tests/integration/ui/compile_fail/attr_crate.stderr
@@ -1,34 +1,34 @@
-error: path must not be relative; specify the path that starts with `crate::` instead; if you want to refer to a reexport from an external crate then use a leading colon like `::crate_name::reexport::path::bon`
+error: path must not be relative; specify the path that starts with `crate::` instead; if you want to refer to a reexport from an external crate then use leading colons like `::crate_name::reexport::path::bon`
  --> tests/integration/ui/compile_fail/attr_crate.rs:4:19
   |
 4 | #[builder(crate = self::bon)]
   |                   ^^^^
 
-error: path must not be relative; specify the path that starts with `crate::` instead; if you want to refer to a reexport from an external crate then use a leading colon like `::crate_name::reexport::path::bon`
+error: path must not be relative; specify the path that starts with `crate::` instead; if you want to refer to a reexport from an external crate then use leading colons like `::crate_name::reexport::path::bon`
  --> tests/integration/ui/compile_fail/attr_crate.rs:8:19
   |
 8 | #[builder(crate = super::bon)]
   |                   ^^^^^
 
-error: path must be absolute; if you want to refer to a reexport from an external crate then add a leading colon like `::bon`; if the path leads to a module in the current crate, then specify the absolute path with `crate` like `crate::reexport::path::bon` or `$crate::reexport::path::bon` (if within a macro)
+error: path must be absolute; if you want to refer to a reexport from an external crate then add leading colons like `::bon`; if the path leads to a module in the current crate, then specify the absolute path with `crate` like `crate::reexport::path::bon` or `$crate::reexport::path::bon` (if within a macro)
   --> tests/integration/ui/compile_fail/attr_crate.rs:12:19
    |
 12 | #[builder(crate = bon)]
    |                   ^^^
 
-error: path must not be relative; specify the path that starts with `crate::` instead; if you want to refer to a reexport from an external crate then use a leading colon like `::crate_name::reexport::path::bon`
+error: path must not be relative; specify the path that starts with `crate::` instead; if you want to refer to a reexport from an external crate then use leading colons like `::crate_name::reexport::path::bon`
   --> tests/integration/ui/compile_fail/attr_crate.rs:15:19
    |
 15 | #[builder(crate = self::bon)]
    |                   ^^^^
 
-error: path must not be relative; specify the path that starts with `crate::` instead; if you want to refer to a reexport from an external crate then use a leading colon like `::crate_name::reexport::path::bon`
+error: path must not be relative; specify the path that starts with `crate::` instead; if you want to refer to a reexport from an external crate then use leading colons like `::crate_name::reexport::path::bon`
   --> tests/integration/ui/compile_fail/attr_crate.rs:18:19
    |
 18 | #[builder(crate = super::bon)]
    |                   ^^^^^
 
-error: path must be absolute; if you want to refer to a reexport from an external crate then add a leading colon like `::bon`; if the path leads to a module in the current crate, then specify the absolute path with `crate` like `crate::reexport::path::bon` or `$crate::reexport::path::bon` (if within a macro)
+error: path must be absolute; if you want to refer to a reexport from an external crate then add leading colons like `::bon`; if the path leads to a module in the current crate, then specify the absolute path with `crate` like `crate::reexport::path::bon` or `$crate::reexport::path::bon` (if within a macro)
   --> tests/integration/ui/compile_fail/attr_crate.rs:21:19
    |
 21 | #[builder(crate = bon)]
@@ -40,19 +40,19 @@ error: `crate` parameter should be specified via `#[bon(crate = path::to::bon)]`
 28 |     #[builder(crate = ::bon)]
    |                       ^
 
-error: path must not be relative; specify the path that starts with `crate::` instead; if you want to refer to a reexport from an external crate then use a leading colon like `::crate_name::reexport::path::bon`
+error: path must not be relative; specify the path that starts with `crate::` instead; if you want to refer to a reexport from an external crate then use leading colons like `::crate_name::reexport::path::bon`
   --> tests/integration/ui/compile_fail/attr_crate.rs:34:15
    |
 34 | #[bon(crate = self::bon)]
    |               ^^^^
 
-error: path must not be relative; specify the path that starts with `crate::` instead; if you want to refer to a reexport from an external crate then use a leading colon like `::crate_name::reexport::path::bon`
+error: path must not be relative; specify the path that starts with `crate::` instead; if you want to refer to a reexport from an external crate then use leading colons like `::crate_name::reexport::path::bon`
   --> tests/integration/ui/compile_fail/attr_crate.rs:40:15
    |
 40 | #[bon(crate = super::bon)]
    |               ^^^^^
 
-error: path must be absolute; if you want to refer to a reexport from an external crate then add a leading colon like `::bon`; if the path leads to a module in the current crate, then specify the absolute path with `crate` like `crate::reexport::path::bon` or `$crate::reexport::path::bon` (if within a macro)
+error: path must be absolute; if you want to refer to a reexport from an external crate then add leading colons like `::bon`; if the path leads to a module in the current crate, then specify the absolute path with `crate` like `crate::reexport::path::bon` or `$crate::reexport::path::bon` (if within a macro)
   --> tests/integration/ui/compile_fail/attr_crate.rs:46:15
    |
 46 | #[bon(crate = bon)]

--- a/bon/tests/integration/ui/compile_fail/warnings.rs
+++ b/bon/tests/integration/ui/compile_fail/warnings.rs
@@ -76,38 +76,4 @@ fn main() {
         builder.get_x2();
         builder.get_x3();
     }
-
-    // Test #[tracing::instrument] placement after #[builder]
-    {
-        use tracing::instrument;
-
-        #[builder]
-        #[instrument]
-        fn bare_instrument() {}
-
-        #[builder]
-        #[instrument(name = "name_override")]
-        fn instrument_with_args() {}
-
-        #[builder]
-        #[tracing::instrument]
-        fn prefixed_instrument() {}
-
-        struct Sut;
-
-        #[bon]
-        impl Sut {
-            #[builder]
-            #[instrument]
-            fn bare_instrument() {}
-
-            #[builder]
-            #[instrument(name = "name_override")]
-            fn instrument_with_args() {}
-
-            #[builder]
-            #[tracing::instrument]
-            fn prefixed_instrument() {}
-        }
-    }
 }

--- a/bon/tests/integration/ui/compile_fail/warnings.stderr
+++ b/bon/tests/integration/ui/compile_fail/warnings.stderr
@@ -1,58 +1,3 @@
-error: use of deprecated module `bon::__::warnings::tracing_instrument_attribute_after_builder`: #[tracing::instrument] attribute should be placed before the #[builder] attribute to make sure it uses the original function name as the span name;
-
-       reason: when the #[tracing::instrument] attribute is placed after the #[builder] attribute it will run after the #[builder] attribute is expanded, at which point the original function will be renamed to __orig_{fn_name}, and this will make that extra __orig_ prefix appear in the span name, which is likely not what you want
-  --> tests/integration/ui/compile_fail/warnings.rs:85:11
-   |
-85 |         #[instrument]
-   |           ^^^^^^^^^^
-   |
-note: the lint level is defined here
-  --> tests/integration/ui/compile_fail/warnings.rs:1:9
-   |
-1  | #![deny(warnings)]
-   |         ^^^^^^^^
-   = note: `#[deny(deprecated)]` implied by `#[deny(warnings)]`
-
-error: use of deprecated module `bon::__::warnings::tracing_instrument_attribute_after_builder`: #[tracing::instrument] attribute should be placed before the #[builder] attribute to make sure it uses the original function name as the span name;
-
-       reason: when the #[tracing::instrument] attribute is placed after the #[builder] attribute it will run after the #[builder] attribute is expanded, at which point the original function will be renamed to __orig_{fn_name}, and this will make that extra __orig_ prefix appear in the span name, which is likely not what you want
-  --> tests/integration/ui/compile_fail/warnings.rs:89:11
-   |
-89 |         #[instrument(name = "name_override")]
-   |           ^^^^^^^^^^
-
-error: use of deprecated module `bon::__::warnings::tracing_instrument_attribute_after_builder`: #[tracing::instrument] attribute should be placed before the #[builder] attribute to make sure it uses the original function name as the span name;
-
-       reason: when the #[tracing::instrument] attribute is placed after the #[builder] attribute it will run after the #[builder] attribute is expanded, at which point the original function will be renamed to __orig_{fn_name}, and this will make that extra __orig_ prefix appear in the span name, which is likely not what you want
-  --> tests/integration/ui/compile_fail/warnings.rs:93:20
-   |
-93 |         #[tracing::instrument]
-   |                    ^^^^^^^^^^
-
-error: use of deprecated module `bon::__::warnings::tracing_instrument_attribute_after_builder`: #[tracing::instrument] attribute should be placed before the #[builder] attribute to make sure it uses the original function name as the span name;
-
-       reason: when the #[tracing::instrument] attribute is placed after the #[builder] attribute it will run after the #[builder] attribute is expanded, at which point the original function will be renamed to __orig_{fn_name}, and this will make that extra __orig_ prefix appear in the span name, which is likely not what you want
-   --> tests/integration/ui/compile_fail/warnings.rs:101:15
-    |
-101 |             #[instrument]
-    |               ^^^^^^^^^^
-
-error: use of deprecated module `bon::__::warnings::tracing_instrument_attribute_after_builder`: #[tracing::instrument] attribute should be placed before the #[builder] attribute to make sure it uses the original function name as the span name;
-
-       reason: when the #[tracing::instrument] attribute is placed after the #[builder] attribute it will run after the #[builder] attribute is expanded, at which point the original function will be renamed to __orig_{fn_name}, and this will make that extra __orig_ prefix appear in the span name, which is likely not what you want
-   --> tests/integration/ui/compile_fail/warnings.rs:105:15
-    |
-105 |             #[instrument(name = "name_override")]
-    |               ^^^^^^^^^^
-
-error: use of deprecated module `bon::__::warnings::tracing_instrument_attribute_after_builder`: #[tracing::instrument] attribute should be placed before the #[builder] attribute to make sure it uses the original function name as the span name;
-
-       reason: when the #[tracing::instrument] attribute is placed after the #[builder] attribute it will run after the #[builder] attribute is expanded, at which point the original function will be renamed to __orig_{fn_name}, and this will make that extra __orig_ prefix appear in the span name, which is likely not what you want
-   --> tests/integration/ui/compile_fail/warnings.rs:109:24
-    |
-109 |             #[tracing::instrument]
-    |                        ^^^^^^^^^^
-
 error: unused `ExampleBuilder` that must be used
   --> tests/integration/ui/compile_fail/warnings.rs:29:9
    |
@@ -60,6 +5,11 @@ error: unused `ExampleBuilder` that must be used
    |         ^^^^^^^^^^^^^^^^^^
    |
    = note: the builder does nothing until you call `build()` on it to finish building
+note: the lint level is defined here
+  --> tests/integration/ui/compile_fail/warnings.rs:1:9
+   |
+1  | #![deny(warnings)]
+   |         ^^^^^^^^
    = note: `#[deny(unused_must_use)]` implied by `#[deny(warnings)]`
 help: use `let _ = ...` to ignore the resulting value
    |

--- a/scripts/test-msrv.sh
+++ b/scripts/test-msrv.sh
@@ -37,8 +37,6 @@ step cargo update -p tokio --precise 1.29.1
 step cargo update -p expect-test --precise 1.4.1
 step cargo update -p windows-sys --precise 0.52.0
 step cargo update -p libc --precise 0.2.163
-step cargo update -p tracing --precise 0.1.40
-step cargo update -p tracing-attributes --precise 0.1.27
 
 export RUSTFLAGS="${RUSTFLAGS:-} --allow unknown-lints"
 


### PR DESCRIPTION
Fixes #268

This is WIP. Need to update automated tests, but I tested it manually and it works.

Used this code as a test:

```rust
struct Foo;

#[bon::bon]
impl Foo {
    #[tracing::instrument]
    #[builder]
    fn method() {
        tracing::info!("Test method");
    }
}

#[bon::builder]
#[tracing::instrument]
fn free_function() {
    tracing::info!("Test free function")
}

fn main() {
    tracing_subscriber::fmt::Subscriber::builder()
        .pretty()
        .init();

    Foo::method().call();
    free_function().call();
}
```

**Before the fix:**
```
  2025-03-19T03:27:21.783193Z  INFO sandbox: Test method
    at crates/sandbox/src/main.rs:8
    in sandbox::__orig_method

  2025-03-19T03:27:21.783254Z  INFO sandbox: Test free function
    at crates/sandbox/src/main.rs:15
    in sandbox::__orig_free_function
```

**After the fix:**
```
  2025-03-19T03:30:44.175971Z  INFO sandbox: Test method
    at crates/sandbox/src/main.rs:8
    in sandbox::method

  2025-03-19T03:30:44.176007Z  INFO sandbox: Test free function
    at crates/sandbox/src/main.rs:15
    in sandbox::free_function
```        