### PR TITLE
Small fix for rust-analyzer syntax highlighting of parameters for functions annotated with `#[builder]`

### DIFF
--- a/bon-macros/src/builder/builder_gen/mod.rs
+++ b/bon-macros/src/builder/builder_gen/mod.rs
@@ -67,10 +67,10 @@ impl BuilderGenCtx {
         // -- Postprocessing --
         // Here we parse all items back and add the `allow` attributes to them.
         let other_items = quote! {
-            #state_mod
             #builder_decl
-            #builder_derives
             #builder_impl
+            #builder_derives
+            #state_mod
         };
 
         let other_items_str = other_items.to_string();


### PR DESCRIPTION
This isn't a complete fix. Unfortunately, the parameters are now getting assigned the semantic token type of `variable` instead of `parameter` after this fix, which is only slightly better than `struct` semantic token type that they were assigned before this fix.

This problem became worse after #269 which added unconditional two-level macro expansion, after which I noticed this problem, although a little later after that patch was released.

Created an issue in rust-analyzer repository to track this problem: https://github.com/rust-lang/rust-analyzer/issues/19556.