### PR TITLE
Add support for propagating `#[track_caller]` and future special attributes

### DIFF
--- a/benchmarks/runtime/src/args_20.rs
+++ b/benchmarks/runtime/src/args_20.rs
@@ -1,3 +1,7 @@
+#![allow(
+    clippy::similar_names,
+    reason = "names don't matter for benching purposes"
+)]
 use bon::builder;
 use std::hint::black_box;
 

--- a/benchmarks/runtime/src/args_20.rs
+++ b/benchmarks/runtime/src/args_20.rs
@@ -1,7 +1,3 @@
-#![allow(
-    clippy::similar_names,
-    reason = "names don't matter for benching purposes"
-)]
 use bon::builder;
 use std::hint::black_box;
 

--- a/benchmarks/runtime/src/lib.rs
+++ b/benchmarks/runtime/src/lib.rs
@@ -9,6 +9,7 @@
     clippy::let_and_return,
     clippy::map_unwrap_or,
     clippy::must_use_candidate,
+    clippy::similar_names,
     rustdoc::missing_crate_level_docs
 )]
 

--- a/bon-macros/src/builder/builder_gen/finish_fn.rs
+++ b/bon-macros/src/builder/builder_gen/finish_fn.rs
@@ -149,7 +149,7 @@ impl super::BuilderGenCtx {
         let body = &self.finish_fn.body.generate(self);
         let asyncness = &self.finish_fn.asyncness;
         let unsafety = &self.finish_fn.unsafety;
-        let must_use = &self.finish_fn.must_use;
+        let special_attrs = &self.finish_fn.special_attrs;
         let attrs = &self.finish_fn.attrs;
         let finish_fn_vis = &self.finish_fn.vis;
         let finish_fn_ident = &self.finish_fn.ident;
@@ -171,7 +171,7 @@ impl super::BuilderGenCtx {
                 clippy::future_not_send,
                 clippy::missing_const_for_fn,
             )]
-            #must_use
+            #(#special_attrs)*
             #finish_fn_vis #const_ #asyncness #unsafety fn #finish_fn_ident(
                 self,
                 #(#finish_fn_params,)*

--- a/bon-macros/src/builder/builder_gen/input_struct.rs
+++ b/bon-macros/src/builder/builder_gen/input_struct.rs
@@ -157,9 +157,9 @@ impl StructInputCtx {
             vis: finish_fn_vis.map(SpannedKey::into_value),
             unsafety: None,
             asyncness: None,
-            must_use: Some(syn::parse_quote! {
+            special_attrs: vec![syn::parse_quote! {
                 #[must_use = "building a struct without using it is likely a bug"]
-            }),
+            }],
             body: Box::new(finish_fn_body),
             output: syn::parse_quote!(-> #struct_ty),
             attrs: finish_fn_docs

--- a/bon-macros/src/builder/builder_gen/models.rs
+++ b/bon-macros/src/builder/builder_gen/models.rs
@@ -56,8 +56,9 @@ pub(super) struct FinishFn {
 
     pub(super) unsafety: Option<syn::Token![unsafe]>,
     pub(super) asyncness: Option<syn::Token![async]>,
-    /// <https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute>
-    pub(super) must_use: Option<syn::Attribute>,
+    /// Special attributes to propagate, such as [`must_use`](<https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute>)
+    /// and [`track_caller`](<https://doc.rust-lang.org/reference/attributes/codegen.html#r-attributes.codegen.track_caller>)
+    pub(super) special_attrs: Vec<syn::Attribute>,
     pub(super) body: Box<dyn FinishFnBody>,
     pub(super) output: syn::ReturnType,
 }
@@ -71,7 +72,7 @@ pub(super) struct FinishFnParams {
     pub(super) attrs: Vec<syn::Attribute>,
     pub(super) unsafety: Option<syn::Token![unsafe]>,
     pub(super) asyncness: Option<syn::Token![async]>,
-    pub(super) must_use: Option<syn::Attribute>,
+    pub(super) special_attrs: Vec<syn::Attribute>,
     pub(super) body: Box<dyn FinishFnBody>,
     pub(super) output: syn::ReturnType,
 }
@@ -316,7 +317,7 @@ impl BuilderGenCtx {
             attrs: finish_fn.attrs,
             unsafety: finish_fn.unsafety,
             asyncness: finish_fn.asyncness,
-            must_use: finish_fn.must_use,
+            special_attrs: finish_fn.special_attrs,
             body: finish_fn.body,
             output: finish_fn.output,
         };

--- a/bon/tests/integration/builder/mod.rs
+++ b/bon/tests/integration/builder/mod.rs
@@ -25,6 +25,7 @@ mod orig_fn_naming;
 mod positional_members;
 mod raw_idents;
 mod smoke;
+mod track_caller;
 
 use crate::prelude::*;
 

--- a/bon/tests/integration/builder/track_caller.rs
+++ b/bon/tests/integration/builder/track_caller.rs
@@ -1,0 +1,64 @@
+use crate::prelude::*;
+use core::panic::Location;
+
+#[test]
+fn track_caller_fn() {
+    #[builder]
+    #[track_caller]
+    fn dont_brick(_x: u32) -> &'static Location<'static> {
+        Location::caller()
+    }
+
+    let location = dont_brick().x(10).call();
+    assert_debug_eq(
+        location,
+        expect![[r#"
+        Location {
+            file: "bon/tests/integration/builder/track_caller.rs",
+            line: 12,
+            col: 39,
+        }"#]],
+    );
+
+    #[track_caller]
+    #[builder]
+    fn dont_brick_2(_x: u32) -> &'static Location<'static> {
+        Location::caller()
+    }
+
+    let location = dont_brick_2().x(10).call();
+    assert_debug_eq(
+        location,
+        expect![[r#"
+            Location {
+                file: "bon/tests/integration/builder/track_caller.rs",
+                line: 29,
+                col: 41,
+            }"#]],
+    );
+}
+
+#[test]
+fn track_caller_impl_block() {
+    struct Brick;
+    struct Senti;
+    #[bon]
+    impl Senti {
+        #[builder(finish_fn = yatta)]
+        #[track_caller]
+        fn new(brick: Brick) -> &'static Location<'static> {
+            let Brick = brick;
+            Location::caller()
+        }
+    }
+    let yatta = Senti::builder().brick(Brick).yatta();
+    assert_debug_eq(
+        yatta,
+        expect![[r#"
+            Location {
+                file: "bon/tests/integration/builder/track_caller.rs",
+                line: 54,
+                col: 47,
+            }"#]],
+    );
+}

--- a/bon/tests/integration/builder/track_caller.rs
+++ b/bon/tests/integration/builder/track_caller.rs
@@ -1,41 +1,41 @@
 use crate::prelude::*;
 use core::panic::Location;
 
+#[derive(Debug)]
+#[allow(dead_code)]
+struct LineCol {
+    line: u32,
+    col: u32,
+}
+
+impl From<&'_ Location<'_>> for LineCol {
+    fn from(value: &'_ Location<'_>) -> Self {
+        Self {
+            line: value.line(),
+            col: value.column(),
+        }
+    }
+}
+
 #[test]
 fn track_caller_fn() {
     #[builder]
     #[track_caller]
-    fn dont_brick(_x: u32) -> &'static Location<'static> {
-        Location::caller()
+    fn dont_brick(_x: u32) -> LineCol {
+        Location::caller().into()
     }
 
     let location = dont_brick().x(10).call();
-    assert_debug_eq(
-        location,
-        expect![[r#"
-        Location {
-            file: "bon/tests/integration/builder/track_caller.rs",
-            line: 12,
-            col: 39,
-        }"#]],
-    );
+    assert_debug_eq(location, expect!["LineCol { line: 28, col: 39 }"]);
 
     #[track_caller]
     #[builder]
-    fn dont_brick_2(_x: u32) -> &'static Location<'static> {
-        Location::caller()
+    fn dont_brick_2(_x: u32) -> LineCol {
+        Location::caller().into()
     }
 
     let location = dont_brick_2().x(10).call();
-    assert_debug_eq(
-        location,
-        expect![[r#"
-            Location {
-                file: "bon/tests/integration/builder/track_caller.rs",
-                line: 29,
-                col: 41,
-            }"#]],
-    );
+    assert_debug_eq(location, expect!["LineCol { line: 37, col: 41 }"]);
 }
 
 #[test]
@@ -46,19 +46,11 @@ fn track_caller_impl_block() {
     impl Senti {
         #[builder(finish_fn = yatta)]
         #[track_caller]
-        fn new(brick: Brick) -> &'static Location<'static> {
+        fn new(brick: Brick) -> LineCol {
             let Brick = brick;
-            Location::caller()
+            Location::caller().into()
         }
     }
     let yatta = Senti::builder().brick(Brick).yatta();
-    assert_debug_eq(
-        yatta,
-        expect![[r#"
-            Location {
-                file: "bon/tests/integration/builder/track_caller.rs",
-                line: 54,
-                col: 47,
-            }"#]],
-    );
+    assert_debug_eq(yatta, expect!["LineCol { line: 54, col: 47 }"]);
 }

--- a/bon/tests/integration/ui/compile_fail/attr_builder.rs
+++ b/bon/tests/integration/ui/compile_fail/attr_builder.rs
@@ -67,3 +67,8 @@ fn destructuring1((x, y): (u32, u32)) {
 
 #[builder]
 fn destructuring2((_, _): (u32, u32)) {}
+
+#[builder]
+#[track_caller]
+#[track_caller]
+fn double_track_caller() {}

--- a/bon/tests/integration/ui/compile_fail/attr_builder.stderr
+++ b/bon/tests/integration/ui/compile_fail/attr_builder.stderr
@@ -83,3 +83,9 @@ error: use a simple `identifier: type` syntax for the function argument; destruc
    |
 69 | fn destructuring2((_, _): (u32, u32)) {}
    |                   ^^^^^^
+
+error: found multiple #[track_caller], but bon only works with exactly one or zero.
+  --> tests/integration/ui/compile_fail/attr_builder.rs:73:1
+   |
+73 | #[track_caller]
+   | ^


### PR DESCRIPTION
As discussed on Discord, propagates `#[track_caller]` on `#[builder]` functions, along with some tiny internal refactors to allow propagating other special attributes in the future.