### PR TITLE
Fix missing support for `#[builder(field)]` with `#[builder(const)]`

### DIFF
--- a/bon-macros/src/builder/builder_gen/finish_fn.rs
+++ b/bon-macros/src/builder/builder_gen/finish_fn.rs
@@ -9,7 +9,7 @@ impl super::BuilderGenCtx {
                 return member
                     .value
                     .as_ref()
-                    .map(|value| self.sanitize_supplied_expr(value))
+                    .map(|value| self.sanitize_expr(value))
                     .unwrap_or_else(|| quote! { ::core::default::Default::default() });
             }
             Member::StartFn(member) => {

--- a/bon-macros/src/builder/builder_gen/finish_fn.rs
+++ b/bon-macros/src/builder/builder_gen/finish_fn.rs
@@ -9,7 +9,7 @@ impl super::BuilderGenCtx {
                 return member
                     .value
                     .as_ref()
-                    .map(|value| self.wrap_user_supplied_expr(value))
+                    .map(|value| self.sanitize_supplied_expr(value))
                     .unwrap_or_else(|| quote! { ::core::default::Default::default() });
             }
             Member::StartFn(member) => {

--- a/bon-macros/src/builder/builder_gen/finish_fn.rs
+++ b/bon-macros/src/builder/builder_gen/finish_fn.rs
@@ -9,17 +9,7 @@ impl super::BuilderGenCtx {
                 return member
                     .value
                     .as_ref()
-                    .map(|value| {
-                        // Closures aren't supported in `const` contexts at the time of this writing
-                        // (Rust 1.86.0), so we don't wrap it in a closure but we require the expression
-                        // to be simple so that it doesn't break out of the surrounding scope.
-                        // Search for `require_embeddable_const_expr` for more.
-                        if self.const_.is_some() {
-                            return quote!(#value);
-                        }
-
-                        quote! { (|| #value)() }
-                    })
+                    .map(|value| self.wrap_user_supplied_expr(value))
                     .unwrap_or_else(|| quote! { ::core::default::Default::default() });
             }
             Member::StartFn(member) => {

--- a/bon-macros/src/builder/builder_gen/member/config/mod.rs
+++ b/bon-macros/src/builder/builder_gen/member/config/mod.rs
@@ -300,29 +300,32 @@ impl MemberConfig {
     }
 
     fn require_const_compat(&self) -> Result {
-        if let Some(default) = &self.default {
-            match &default.value {
-                Some(expr) => crate::parsing::require_embeddable_const_expr(expr)?,
-                None => bail!(
-                    &default.key,
-                    "bare #[builder(default)] is incompatible with #[builder(const)] \
-                    because Default::default() can not be called in const context; \
-                    provide an explicit default value via #[builder(default = ...)] instead",
-                ),
+        // This is a small private function to reduce code duplication, we don't
+        // need explicit `as_ref` at the callsite in this case.
+        #[allow(clippy::ref_option)]
+        fn validate_default_trait_or_expr(attr: &Option<SpannedKey<Option<syn::Expr>>>) -> Result {
+            let attr = match attr {
+                Some(attr) => attr,
+                None => return Ok(()),
+            };
+
+            let name = attr.key.to_string();
+
+            if let Some(expr) = &attr.value {
+                return crate::parsing::require_embeddable_const_expr(expr);
             }
+
+            bail!(
+                &attr.key,
+                "bare #[builder({name})] is incompatible with #[builder(const)] \
+                because Default::default() can not be called in const context; \
+                provide an explicit value via #[builder({name} = ...)] instead",
+            )
         }
 
-        if let Some(skip) = &self.skip {
-            match &skip.value {
-                Some(expr) => crate::parsing::require_embeddable_const_expr(expr)?,
-                None => bail!(
-                    &skip.key,
-                    "bare #[builder(skip)] is incompatible with #[builder(const)] \
-                    because Default::default() can not be called in const context; \
-                    provide an explicit initial value via #[builder(skip = ...)] instead",
-                ),
-            }
-        }
+        validate_default_trait_or_expr(&self.default)?;
+        validate_default_trait_or_expr(&self.skip)?;
+        validate_default_trait_or_expr(&self.field)?;
 
         if self.into.is_present() {
             bail!(

--- a/bon-macros/src/builder/builder_gen/member/config/mod.rs
+++ b/bon-macros/src/builder/builder_gen/member/config/mod.rs
@@ -300,9 +300,6 @@ impl MemberConfig {
     }
 
     fn require_const_compat(&self) -> Result {
-        // This is a small private function to reduce code duplication, we don't
-        // need explicit `as_ref` at the callsite in this case.
-        #[allow(clippy::ref_option)]
         fn validate_default_trait_or_expr(attr: &Option<SpannedKey<Option<syn::Expr>>>) -> Result {
             let attr = match attr {
                 Some(attr) => attr,

--- a/bon-macros/src/builder/builder_gen/member/named.rs
+++ b/bon-macros/src/builder/builder_gen/member/named.rs
@@ -182,8 +182,6 @@ impl NamedMember {
         Ok(())
     }
 
-    // `&Option<T>` is used to reduce syntax at the call site
-    #[allow(clippy::ref_option)]
     fn validate_unused_setters_cfg<T>(
         overrides: &[&SpannedKey<ItemSigConfig>],
         config: &Option<SpannedKey<T>>,

--- a/bon-macros/src/builder/builder_gen/mod.rs
+++ b/bon-macros/src/builder/builder_gen/mod.rs
@@ -288,7 +288,7 @@ impl BuilderGenCtx {
     ///
     /// This function assumes the expression underwent a `require_embeddable_const_expr`
     /// check if `const` is enabled. Search for it in code to see where it happens.
-    fn sanitize_supplied_expr(&self, expr: &syn::Expr) -> TokenStream {
+    fn sanitize_expr(&self, expr: &syn::Expr) -> TokenStream {
         if self.const_.is_some() {
             return quote!(#expr);
         }

--- a/bon-macros/src/builder/builder_gen/mod.rs
+++ b/bon-macros/src/builder/builder_gen/mod.rs
@@ -277,6 +277,26 @@ impl BuilderGenCtx {
             )>
         }
     }
+
+    /// Wrap the user-supplied expression in a closure to prevent it from
+    /// breaking out of the surrounding scope.
+    ///
+    /// Closures aren't supported in `const` contexts at the time of this writing
+    /// (Rust 1.86.0), so we don't wrap the expression in a closure in `const` case
+    /// but we require the expression to be simple so that it doesn't break out of
+    /// the surrounding scope.
+    ///
+    /// This function assumes the expression underwent a `require_embeddable_const_expr`
+    /// check if `const` is enabled. Search for it in code to see where it happens.
+    fn wrap_user_supplied_expr(&self, expr: &syn::Expr) -> TokenStream {
+        if self.const_.is_some() {
+            return quote!(#expr);
+        }
+
+        quote! {
+            (|| #expr)()
+        }
+    }
 }
 
 fn allow_warnings_on_member_types() -> TokenStream {

--- a/bon-macros/src/builder/builder_gen/mod.rs
+++ b/bon-macros/src/builder/builder_gen/mod.rs
@@ -288,7 +288,7 @@ impl BuilderGenCtx {
     ///
     /// This function assumes the expression underwent a `require_embeddable_const_expr`
     /// check if `const` is enabled. Search for it in code to see where it happens.
-    fn wrap_user_supplied_expr(&self, expr: &syn::Expr) -> TokenStream {
+    fn sanitize_supplied_expr(&self, expr: &syn::Expr) -> TokenStream {
         if self.const_.is_some() {
             return quote!(#expr);
         }

--- a/bon-macros/src/builder/builder_gen/start_fn.rs
+++ b/bon-macros/src/builder/builder_gen/start_fn.rs
@@ -69,7 +69,7 @@ impl super::BuilderGenCtx {
             let init = field
                 .init
                 .as_ref()
-                .map(|init| self.wrap_user_supplied_expr(init))
+                .map(|init| self.sanitize_supplied_expr(init))
                 .unwrap_or_else(|| quote! { ::core::default::Default::default() });
 
             quote! {

--- a/bon-macros/src/builder/builder_gen/start_fn.rs
+++ b/bon-macros/src/builder/builder_gen/start_fn.rs
@@ -69,7 +69,7 @@ impl super::BuilderGenCtx {
             let init = field
                 .init
                 .as_ref()
-                .map(|init| quote! { (|| #init)() })
+                .map(|init| self.wrap_user_supplied_expr(init))
                 .unwrap_or_else(|| quote! { ::core::default::Default::default() });
 
             quote! {

--- a/bon-macros/src/builder/builder_gen/start_fn.rs
+++ b/bon-macros/src/builder/builder_gen/start_fn.rs
@@ -69,7 +69,7 @@ impl super::BuilderGenCtx {
             let init = field
                 .init
                 .as_ref()
-                .map(|init| self.sanitize_supplied_expr(init))
+                .map(|init| self.sanitize_expr(init))
                 .unwrap_or_else(|| quote! { ::core::default::Default::default() });
 
             quote! {

--- a/bon-macros/src/lib.rs
+++ b/bon-macros/src/lib.rs
@@ -11,6 +11,12 @@
     clippy::too_many_lines,
     clippy::if_not_else,
 
+    // This crate doesn't expose complex public function signatures, any occurrences
+    // of `&Option<T>` are internal and they are likely just small private functions
+    // that take a reference to an `Option<T>` to make the callsite cleaner avoiding
+    // the unnecessary `Option::as_ref()` calls.
+    clippy::ref_option,
+
     // We can't use the explicit captures syntax due to the MSRV
     impl_trait_overcaptures,
 

--- a/bon-macros/src/parsing/mod.rs
+++ b/bon-macros/src/parsing/mod.rs
@@ -95,8 +95,6 @@ fn parse_path_mod_style(meta: &syn::Meta) -> Result<syn::Path> {
     Ok(expr.require_path_mod_style()?.clone())
 }
 
-// `&Option<T>` is used to reduce syntax at the callsite
-#[allow(clippy::ref_option)]
 pub(crate) fn reject_syntax<T: Spanned>(name: &'static str, syntax: &Option<T>) -> Result {
     if let Some(syntax) = syntax {
         bail!(syntax, "{name} is not allowed here")

--- a/bon/tests/integration/builder/attr_const.rs
+++ b/bon/tests/integration/builder/attr_const.rs
@@ -48,13 +48,6 @@ mod msrv_1_61 {
                 // x8: String,
             }
 
-            impl<S: sut_builder::State> SutBuilder<S> {
-                const fn inc(&mut self) {
-                    self.x1 += 1;
-                    self.x2 += 1;
-                }
-            }
-
             const ACTUAL: Sut = Sut::builder(1).x4(2).x5(3).x7(4, 5).build(6);
 
             #[allow(clippy::assertions_on_constants)]
@@ -69,15 +62,37 @@ mod msrv_1_61 {
                 assert!(ACTUAL.x8.is_none());
                 assert!(ACTUAL.x9 == 10);
             }
-
-            {
-                let mut builder = Sut::builder(1);
-                builder.inc();
-                builder.inc();
-                assert!(builder.x1 == 3);
-                assert!(builder.x2 == 13);
-            }
         }
+
+        #[test]
+        #[rustversion::since(1.83.0)]
+        const fn test_struct_msrv_1_83() {
+            #[derive(Builder)]
+            #[builder(const)]
+            struct Sut {
+                #[builder(start_fn)]
+                #[allow(dead_code)]
+                x1: u32,
+
+                #[builder(field = 11)]
+                #[allow(dead_code)]
+                x2: u32,
+            }
+
+            impl<S: sut_builder::State> SutBuilder<S> {
+                const fn inc(&mut self) {
+                    self.x1 += 1;
+                    self.x2 += 1;
+                }
+            }
+
+            let mut builder = Sut::builder(1);
+            builder.inc();
+            builder.inc();
+            assert!(builder.x1 == 3);
+            assert!(builder.x2 == 13);
+        }
+
         #[test]
         const fn test_function() {
             type Output = (u32, u32, u32, u32, Option<u32>, u32, u32, Option<u32>);

--- a/bon/tests/integration/builder/attr_const.rs
+++ b/bon/tests/integration/builder/attr_const.rs
@@ -14,24 +14,29 @@ mod msrv_1_61 {
                 #[builder(start_fn)]
                 x1: u32,
 
-                #[builder(finish_fn)]
+                // There was a bug in `#[builder(field)]` `const` support, that
+                // this is testing for: https://github.com/elastio/bon/issues/290
+                #[builder(field = 11)]
                 x2: u32,
 
+                #[builder(finish_fn)]
                 x3: u32,
 
-                x4: Option<u32>,
+                x4: u32,
+
+                x5: Option<u32>,
 
                 #[builder(default = x1 + 99)]
-                x5: u32,
-
-                #[builder(with = |a: u32, b: u32| a + b)]
                 x6: u32,
 
+                #[builder(with = |a: u32, b: u32| a + b)]
+                x7: u32,
+
                 #[builder(with = |a: u32, b: u32| -> Result<_, ()> { Ok(a + b) })]
-                x7: Option<u32>,
+                x8: Option<u32>,
 
                 #[builder(skip = 10)]
-                x8: u32,
+                x9: u32,
                 //
                 // This doesn't work because Rust complains about this in setters that
                 // consume `self` and return a new instance of the builder:
@@ -43,60 +48,79 @@ mod msrv_1_61 {
                 // x8: String,
             }
 
-            const ACTUAL: Sut = Sut::builder(1).x3(2).x4(3).x6(4, 5).build(6);
+            impl<S: sut_builder::State> SutBuilder<S> {
+                const fn inc(&mut self) {
+                    self.x1 += 1;
+                    self.x2 += 1;
+                }
+            }
+
+            const ACTUAL: Sut = Sut::builder(1).x4(2).x5(3).x7(4, 5).build(6);
 
             #[allow(clippy::assertions_on_constants)]
             {
                 assert!(ACTUAL.x1 == 1);
-                assert!(ACTUAL.x2 == 6);
-                assert!(ACTUAL.x3 == 2);
-                assert!(matches!(ACTUAL.x4, Some(3)));
-                assert!(ACTUAL.x5 == 100);
-                assert!(ACTUAL.x6 == 9);
-                assert!(ACTUAL.x7.is_none());
-                assert!(ACTUAL.x8 == 10);
+                assert!(ACTUAL.x2 == 11);
+                assert!(ACTUAL.x3 == 6);
+                assert!(ACTUAL.x4 == 2);
+                assert!(matches!(ACTUAL.x5, Some(3)));
+                assert!(ACTUAL.x6 == 100);
+                assert!(ACTUAL.x7 == 9);
+                assert!(ACTUAL.x8.is_none());
+                assert!(ACTUAL.x9 == 10);
+            }
+
+            {
+                let mut builder = Sut::builder(1);
+                builder.inc();
+                builder.inc();
+                assert!(builder.x1 == 3);
+                assert!(builder.x2 == 13);
             }
         }
         #[test]
         const fn test_function() {
-            type Output = (u32, u32, u32, Option<u32>, u32, u32, Option<u32>);
+            type Output = (u32, u32, u32, u32, Option<u32>, u32, u32, Option<u32>);
 
             #[builder(const)]
             const fn sut(
                 #[builder(start_fn)] x1: u32,
 
-                #[builder(finish_fn)] x2: u32,
+                #[builder(field = 10)] x2: u32,
 
-                x3: u32,
+                #[builder(finish_fn)] x3: u32,
 
-                x4: Option<u32>,
+                x4: u32,
 
-                #[builder(default = x1 + 99)] x5: u32,
+                x5: Option<u32>,
 
-                #[builder(with = |a: u32, b: u32| a + b)] x6: u32,
+                #[builder(default = x1 + 99)] x6: u32,
 
-                #[builder(with = |a: u32, b: u32| -> Result<_, ()> { Ok(a + b) })] x7: Option<u32>,
+                #[builder(with = |a: u32, b: u32| a + b)] x7: u32,
+
+                #[builder(with = |a: u32, b: u32| -> Result<_, ()> { Ok(a + b) })] x8: Option<u32>,
             ) -> Output {
-                (x1, x2, x3, x4, x5, x6, x7)
+                (x1, x2, x3, x4, x5, x6, x7, x8)
             }
 
-            const ACTUAL: Output = sut(1).x3(2).x4(3).x6(4, 5).call(6);
+            const ACTUAL: Output = sut(1).x4(2).x5(3).x7(4, 5).call(6);
 
             #[allow(clippy::assertions_on_constants)]
             {
                 assert!(ACTUAL.0 == 1);
-                assert!(ACTUAL.1 == 6);
-                assert!(ACTUAL.2 == 2);
-                assert!(matches!(ACTUAL.3, Some(3)));
-                assert!(ACTUAL.4 == 100);
-                assert!(ACTUAL.5 == 9);
-                assert!(ACTUAL.6.is_none());
+                assert!(ACTUAL.1 == 10);
+                assert!(ACTUAL.2 == 6);
+                assert!(ACTUAL.3 == 2);
+                assert!(matches!(ACTUAL.4, Some(3)));
+                assert!(ACTUAL.5 == 100);
+                assert!(ACTUAL.6 == 9);
+                assert!(ACTUAL.7.is_none());
             }
         }
 
         #[test]
         const fn test_method() {
-            type Output = (u32, u32, u32, Option<u32>, u32, u32, Option<u32>);
+            type Output = (u32, u32, u32, u32, Option<u32>, u32, u32, Option<u32>);
 
             struct Sut;
 
@@ -106,35 +130,38 @@ mod msrv_1_61 {
                 const fn sut(
                     #[builder(start_fn)] x1: u32,
 
-                    #[builder(finish_fn)] x2: u32,
+                    #[builder(field = 10)] x2: u32,
 
-                    x3: u32,
+                    #[builder(finish_fn)] x3: u32,
 
-                    x4: Option<u32>,
+                    x4: u32,
 
-                    #[builder(default = x1 + 99)] x5: u32,
+                    x5: Option<u32>,
 
-                    #[builder(with = |a: u32, b: u32| a + b)] x6: u32,
+                    #[builder(default = x1 + 99)] x6: u32,
 
-                    #[builder(with = |a: u32, b: u32| -> Result<_, ()> { Ok(a + b) })] x7: Option<
+                    #[builder(with = |a: u32, b: u32| a + b)] x7: u32,
+
+                    #[builder(with = |a: u32, b: u32| -> Result<_, ()> { Ok(a + b) })] x8: Option<
                         u32,
                     >,
                 ) -> Output {
-                    (x1, x2, x3, x4, x5, x6, x7)
+                    (x1, x2, x3, x4, x5, x6, x7, x8)
                 }
             }
 
-            const ACTUAL: Output = Sut::sut(1).x3(2).x4(3).x6(4, 5).call(6);
+            const ACTUAL: Output = Sut::sut(1).x4(2).x5(3).x7(4, 5).call(6);
 
             #[allow(clippy::assertions_on_constants)]
             {
                 assert!(ACTUAL.0 == 1);
-                assert!(ACTUAL.1 == 6);
-                assert!(ACTUAL.2 == 2);
-                assert!(matches!(ACTUAL.3, Some(3)));
-                assert!(ACTUAL.4 == 100);
-                assert!(ACTUAL.5 == 9);
-                assert!(ACTUAL.6.is_none());
+                assert!(ACTUAL.1 == 10);
+                assert!(ACTUAL.2 == 6);
+                assert!(ACTUAL.3 == 2);
+                assert!(matches!(ACTUAL.4, Some(3)));
+                assert!(ACTUAL.5 == 100);
+                assert!(ACTUAL.6 == 9);
+                assert!(ACTUAL.7.is_none());
             }
         }
     }
@@ -142,6 +169,23 @@ mod msrv_1_61 {
     // Tests for the following bug: https://github.com/elastio/bon/issues/287
     mod visibility {
         use crate::prelude::*;
+
+        #[test]
+        const fn test_struct() {
+            #[derive(Builder)]
+            #[builder(const)]
+            #[allow(unreachable_pub)]
+            pub struct Sut {
+                x1: u32,
+            }
+
+            const ACTUAL: Sut = Sut::builder().x1(1).build();
+
+            #[allow(clippy::assertions_on_constants)]
+            {
+                assert!(ACTUAL.x1 == 1);
+            }
+        }
 
         #[test]
         const fn test_function() {

--- a/bon/tests/integration/builder/attr_const.rs
+++ b/bon/tests/integration/builder/attr_const.rs
@@ -64,8 +64,8 @@ mod msrv_1_61 {
             }
         }
 
-        #[test]
         #[rustversion::since(1.83.0)]
+        #[test]
         const fn test_struct_msrv_1_83() {
             #[derive(Builder)]
             #[builder(const)]

--- a/bon/tests/integration/ui/compile_fail/attr_const.rs
+++ b/bon/tests/integration/ui/compile_fail/attr_const.rs
@@ -27,6 +27,13 @@ struct IncompatibleSkip {
 
 #[derive(Builder)]
 #[builder(const)]
+struct IncompatibleField {
+    #[builder(field)]
+    x1: u32,
+}
+
+#[derive(Builder)]
+#[builder(const)]
 struct IncompatibleInto {
     #[builder(into)]
     x1: u32,

--- a/bon/tests/integration/ui/compile_fail/attr_const.stderr
+++ b/bon/tests/integration/ui/compile_fail/attr_const.stderr
@@ -10,38 +10,44 @@ error: #[builder(const)] requires the underlying function to be marked as `const
 10 |     #[builder(const)]
    |               ^^^^^
 
-error: bare #[builder(default)] is incompatible with #[builder(const)] because Default::default() can not be called in const context; provide an explicit default value via #[builder(default = ...)] instead
+error: bare #[builder(default)] is incompatible with #[builder(const)] because Default::default() can not be called in const context; provide an explicit value via #[builder(default = ...)] instead
   --> tests/integration/ui/compile_fail/attr_const.rs:17:15
    |
 17 |     #[builder(default)]
    |               ^^^^^^^
 
-error: bare #[builder(skip)] is incompatible with #[builder(const)] because Default::default() can not be called in const context; provide an explicit initial value via #[builder(skip = ...)] instead
+error: bare #[builder(skip)] is incompatible with #[builder(const)] because Default::default() can not be called in const context; provide an explicit value via #[builder(skip = ...)] instead
   --> tests/integration/ui/compile_fail/attr_const.rs:24:15
    |
 24 |     #[builder(skip)]
    |               ^^^^
 
-error: #[builder(into)] is incompatible with #[builder(const)] because Into::into() can not be called in const context
+error: bare #[builder(field)] is incompatible with #[builder(const)] because Default::default() can not be called in const context; provide an explicit value via #[builder(field = ...)] instead
   --> tests/integration/ui/compile_fail/attr_const.rs:31:15
    |
-31 |     #[builder(into)]
-   |               ^^^^
+31 |     #[builder(field)]
+   |               ^^^^^
 
-error: from_iter is incompatible with #[builder(const)] because FromIterator::from_iter() can not be called in const context
-  --> tests/integration/ui/compile_fail/attr_const.rs:38:22
+error: #[builder(into)] is incompatible with #[builder(const)] because Into::into() can not be called in const context
+  --> tests/integration/ui/compile_fail/attr_const.rs:38:15
    |
-38 |     #[builder(with = FromIterator::from_iter)]
-   |                      ^^^^^^^^^^^^
+38 |     #[builder(into)]
+   |               ^^^^
 
 error: from_iter is incompatible with #[builder(const)] because FromIterator::from_iter() can not be called in const context
   --> tests/integration/ui/compile_fail/attr_const.rs:45:22
    |
-45 |     #[builder(with = <_>::from_iter)]
+45 |     #[builder(with = FromIterator::from_iter)]
+   |                      ^^^^^^^^^^^^
+
+error: from_iter is incompatible with #[builder(const)] because FromIterator::from_iter() can not be called in const context
+  --> tests/integration/ui/compile_fail/attr_const.rs:52:22
+   |
+52 |     #[builder(with = <_>::from_iter)]
    |                      ^
 
 error: this kind of expression is not allowed in this position; if you need to use a complex expression such as this then move it into a separate `const fn` and call that function here instead
-  --> tests/integration/ui/compile_fail/attr_const.rs:52:25
+  --> tests/integration/ui/compile_fail/attr_const.rs:59:25
    |
-52 |     #[builder(default = return 1)]
+59 |     #[builder(default = return 1)]
    |                         ^^^^^^


### PR DESCRIPTION
Closes https://github.com/elastio/bon/issues/290