### PR TITLE
Add supporters section, improve socials and visual stuff a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,9 @@ Big thanks to `bon`'s financial supporters ❤️
 **Ethan Skowronski**\
 <sup><code>$1/month</code></sup>
 
+**Julius Lungys**\
+<sup><code>$1/month</code></sup>
+
 </div>
 
 ## Who's Using `bon`?

--- a/README.md
+++ b/README.md
@@ -216,25 +216,16 @@ See [alternatives](https://bon-rs.com/guide/alternatives) for comparison.
 
 Big thanks to `bon`'s financial supporters ❤️
 
-<a href="https://kindness.ai/">
-<img src="https://github.com/user-attachments/assets/b7b7e027-0b34-442c-a630-1c07514d800a" width="100px"></img>
-</a>
-<a href="https://kindness.ai/">Kindness</a>
+[![](https://github.com/user-attachments/assets/b0acb844-4b91-461c-95ae-90a601296500)](https://kindness.ai)\
+[**Kindness**](https://kindness.ai)
 
-Ethan Skowronski
+**Ethan Skowronski**
 
 </div>
 
 ## Who's Using `bon`?
 
-Some notable open-source users:
-
-- [`crates.io` backend](https://github.com/rust-lang/crates.io)
-- [`tantivy`](https://github.com/quickwit-oss/tantivy)
-- [`apache-avro`](https://github.com/apache/avro-rs)
-- [`google-cloud-auth`](https://github.com/googleapis/google-cloud-rust)
-- [`comrak`](https://github.com/kivikakk/comrak)
-- [`ractor`](https://github.com/slawlor/ractor)
+Some notable open-source users: [`crates.io` backend](https://github.com/rust-lang/crates.io), [`tantivy`](https://github.com/quickwit-oss/tantivy), [`apache-avro`](https://github.com/apache/avro-rs), [`google-cloud-auth`](https://github.com/googleapis/google-cloud-rust), [`comrak`](https://github.com/kivikakk/comrak), [`ractor`](https://github.com/slawlor/ractor)
 
 ## Getting Help
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,20 @@ This project was heavily inspired by such awesome crates as [`buildstructor`](ht
 
 See [alternatives](https://bon-rs.com/guide/alternatives) for comparison.
 
+## Supporters
+
+<div align="center">
+
+Big thanks to `bon`'s financial supporters ❤️
+
+<img src="https://github.com/user-attachments/assets/b7b7e027-0b34-442c-a630-1c07514d800a" width="100px"></img>
+
+[**Kindness**](https://kindness.ai/)
+
+Ethan Skowronski
+
+</div>
+
 ## Who's Using `bon`?
 
 Some notable users:
@@ -217,7 +231,7 @@ Some notable users:
 - [`crates.io` backend](https://github.com/rust-lang/crates.io)
 - [`ractor`](https://github.com/slawlor/ractor)
 - [`comrak`](https://github.com/kivikakk/comrak)
-- [`soldeer`](https://github.com/mario-eth/soldeer) (package manager endorsed by [`foundry`](https://github.com/foundry-rs/foundry))
+- [`soldeer`](https://github.com/mario-eth/soldeer)
 - [`tachyonfx`](https://github.com/junkdog/tachyonfx)
 
 ## Getting Help
@@ -231,10 +245,6 @@ If you can't figure something out, consult the docs and maybe use the `🔍 Sear
     <tr>
         <td><a href="https://bon-rs.com/discord">Discord</a></td>
         <td>Here you can leave feedback, ask questions, report bugs, or just write "thank you".</td>
-    </tr>
-    <tr>
-        <td><a href="https://x.com/veetaha" class="nobr">X (Twitter)</a></td>
-        <td>Profile of the maintainer. There are only posts about <code>bon</code> and Rust in general here.</td>
     </tr>
 </tbody>
 </table>

--- a/README.md
+++ b/README.md
@@ -217,9 +217,9 @@ See [alternatives](https://bon-rs.com/guide/alternatives) for comparison.
 Big thanks to `bon`'s financial supporters ❤️
 
 [![](https://github.com/user-attachments/assets/b0acb844-4b91-461c-95ae-90a601296500)](https://kindness.ai)\
-[**Kindness**](https://kindness.ai)
+[**Kindness**](https://kindness.ai) ($100/month)
 
-**Ethan Skowronski**
+**Ethan Skowronski** ($1/month)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -217,9 +217,11 @@ See [alternatives](https://bon-rs.com/guide/alternatives) for comparison.
 Big thanks to `bon`'s financial supporters ❤️
 
 [![](https://github.com/user-attachments/assets/b0acb844-4b91-461c-95ae-90a601296500)](https://kindness.ai)\
-[**Kindness**](https://kindness.ai) ($100/month)
+[**Kindness**](https://kindness.ai) \
+<sup><code>$100/month</code></sup>
 
-**Ethan Skowronski** ($1/month)
+**Ethan Skowronski**\
+<sup><code>$1/month</code></sup>
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -216,9 +216,10 @@ See [alternatives](https://bon-rs.com/guide/alternatives) for comparison.
 
 Big thanks to `bon`'s financial supporters ❤️
 
+<a href="https://kindness.ai/">
 <img src="https://github.com/user-attachments/assets/b7b7e027-0b34-442c-a630-1c07514d800a" width="100px"></img>
-
-[**Kindness**](https://kindness.ai/)
+</a>
+<a href="https://kindness.ai/">Kindness</a>
 
 Ethan Skowronski
 
@@ -226,13 +227,14 @@ Ethan Skowronski
 
 ## Who's Using `bon`?
 
-Some notable users:
+Some notable open-source users:
 
 - [`crates.io` backend](https://github.com/rust-lang/crates.io)
-- [`ractor`](https://github.com/slawlor/ractor)
+- [`tantivy`](https://github.com/quickwit-oss/tantivy)
+- [`apache-avro`](https://github.com/apache/avro-rs)
+- [`google-cloud-auth`](https://github.com/googleapis/google-cloud-rust)
 - [`comrak`](https://github.com/kivikakk/comrak)
-- [`soldeer`](https://github.com/mario-eth/soldeer)
-- [`tachyonfx`](https://github.com/junkdog/tachyonfx)
+- [`ractor`](https://github.com/slawlor/ractor)
 
 ## Getting Help
 
@@ -244,7 +246,7 @@ If you can't figure something out, consult the docs and maybe use the `🔍 Sear
 <tbody>
     <tr>
         <td><a href="https://bon-rs.com/discord">Discord</a></td>
-        <td>Here you can leave feedback, ask questions, report bugs, or just write "thank you".</td>
+        <td>Here you can leave feedback, ask questions, report bugs, etc.</td>
     </tr>
 </tbody>
 </table>

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Big thanks to `bon`'s financial supporters ❤️
 
 ## Who's Using `bon`?
 
-Some notable open-source users: [`crates.io` backend](https://github.com/rust-lang/crates.io), [`tantivy`](https://github.com/quickwit-oss/tantivy), [`apache-avro`](https://github.com/apache/avro-rs), [`google-cloud-auth`](https://github.com/googleapis/google-cloud-rust), [`comrak`](https://github.com/kivikakk/comrak), [`ractor`](https://github.com/slawlor/ractor)
+Some notable open-source users: [`crates.io` backend](https://github.com/rust-lang/crates.io), [`tantivy`](https://github.com/quickwit-oss/tantivy), [`apache-avro`](https://github.com/apache/avro-rs), [`google-cloud-auth`](https://github.com/googleapis/google-cloud-rust), [`comrak`](https://github.com/kivikakk/comrak), [`ractor`](https://github.com/slawlor/ractor).
 
 ## Getting Help
 

--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -124,7 +124,10 @@ export default defineConfig({
         socialLinks: [
             { icon: "github", link: "https://github.com/elastio/bon" },
             { icon: "discord", link: "https://bon-rs.com/discord" },
-            { icon: "x", link: "https://x.com/veetaha" },
+            {
+                icon: "opencollective",
+                link: "https://opencollective.com/bon-rs",
+            },
             { icon: "patreon", link: "https://patreon.com/Veetaha" },
             { icon: "kofi", link: "https://ko-fi.com/Veetaha" },
         ],

--- a/website/src/guide/overview.md
+++ b/website/src/guide/overview.md
@@ -1,1 +1,8 @@
+<!-- Small hack to avoid an extra empty line between the company logo and its name -->
+<style>
+a[href="https://kindness.ai"] + br {
+    display: none;
+}
+</style>
+
 <!--@include: ../../../README.md#overview-->

--- a/website/src/guide/overview.md
+++ b/website/src/guide/overview.md
@@ -1,6 +1,6 @@
 <!-- Small hack to avoid an extra empty line between the company logo and its name -->
 <style>
-a[href="https://kindness.ai"] + br {
+    a[href="https://kindness.ai"]:first-child + br {
     display: none;
 }
 </style>


### PR DESCRIPTION
cc @lazkindness / @beyera

I've added the "supporters" section to the readme, I'll keep it even for past supporters. See how it looks below.
Let me know if this works for you. Also if you have a source image of the heart logo with transparent background I'd appreciate that. I took the logo from the OpenCollective page and removed white background from it myself  for now.

![image](https://github.com/user-attachments/assets/153de38d-6964-4724-bfa2-0f370149f07a)
![image](https://github.com/user-attachments/assets/8661501b-1e03-447c-ab7b-44ba958bbcff)
![image](https://github.com/user-attachments/assets/dcfc406a-525e-4134-9bd0-2221105d7264)
