### PR TITLE
Fix cargo binstall missing binary of iai-callgrind-runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
 
       - uses: taiki-e/install-action@cargo-binstall
       - run: cargo binstall iai-callgrind-runner --version $(cargo pkgid iai-callgrind | cut -d@ -f2)
+      - run: cargo binstall --help
 
       - run: sudo apt-get update && sudo apt-get install -y valgrind
       - run: cd ./benchmarks/runtime && ./run.sh ${{ matrix.benchmark }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - run: ls -lah /home/runner/.cargo/bin || true
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - run: ls -lah /home/runner/.cargo/bin || true
 
       - uses: taiki-e/install-action@cargo-binstall
       - run: cargo binstall iai-callgrind-runner --version $(cargo pkgid iai-callgrind | cut -d@ -f2)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,13 +41,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - run: ls -lah /home/runner/.cargo/bin || true
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - run: ls -lah /home/runner/.cargo/bin || true
-      - run: cat /home/runner/.cargo/.crates.toml
-
       - uses: taiki-e/install-action@cargo-binstall
-      - run: cargo binstall iai-callgrind-runner@$(cargo pkgid iai-callgrind | cut -d@ -f2)
+
+      # Using `--force` flag because the caching action has this bug:
+      # https://github.com/Swatinem/rust-cache/issues/204
+      - run: cargo binstall --force iai-callgrind-runner@$(cargo pkgid iai-callgrind | cut -d@ -f2)
+
       - run: iai-callgrind-runner --help
 
       - run: sudo apt-get update && sudo apt-get install -y valgrind

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,6 @@ jobs:
       # https://github.com/Swatinem/rust-cache/issues/204
       - run: cargo binstall --force iai-callgrind-runner@$(cargo pkgid iai-callgrind | cut -d@ -f2)
 
-      - run: iai-callgrind-runner --help
-
       - run: sudo apt-get update && sudo apt-get install -y valgrind
       - run: cd ./benchmarks/runtime && ./run.sh ${{ matrix.benchmark }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - run: cat /home/runner/.cargo/.crates.toml
 
       - uses: taiki-e/install-action@cargo-binstall
-      - run: cargo binstall iai-callgrind-runner --version $(cargo pkgid iai-callgrind | cut -d@ -f2)
+      - run: cargo binstall iai-callgrind-runner@$(cargo pkgid iai-callgrind | cut -d@ -f2)
       - run: iai-callgrind-runner --help
 
       - run: sudo apt-get update && sudo apt-get install -y valgrind

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
 
       - uses: taiki-e/install-action@cargo-binstall
       - run: cargo binstall iai-callgrind-runner --version $(cargo pkgid iai-callgrind | cut -d@ -f2)
-      - run: cargo binstall --help
+      - run: iai-callgrind-runner --help
 
       - run: sudo apt-get update && sudo apt-get install -y valgrind
       - run: cd ./benchmarks/runtime && ./run.sh ${{ matrix.benchmark }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
       - run: ls -lah /home/runner/.cargo/bin || true
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: ls -lah /home/runner/.cargo/bin || true
+      - run: cat /home/runner/.cargo/.crates.toml
 
       - uses: taiki-e/install-action@cargo-binstall
       - run: cargo binstall iai-callgrind-runner --version $(cargo pkgid iai-callgrind | cut -d@ -f2)


### PR DESCRIPTION
Related issues:
- https://github.com/Swatinem/rust-cache/issues/204
- https://github.com/cargo-bins/cargo-binstall/issues/2215