### PR TITLE
Migrate to OIDC for trusted publishing to crates.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,13 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+
       - uses: MarcoIeni/release-plz-action@v0.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
   deploy-website:
     needs: release-rust-crates


### PR DESCRIPTION
Based on the crates.io [announcement](https://blog.rust-lang.org/2025/07/11/crates-io-development-update-2025-07/) of OIDC support