### PR TITLE
Add support for `derive(IntoFuture(Box))`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,28 +45,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,12 +134,6 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
-
-[[package]]
-name = "bytes"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cast"
@@ -447,7 +419,7 @@ dependencies = [
  "itertools 0.14.0",
  "lazy-regex",
  "macro_rules_attribute",
- "tokio-test",
+ "tokio",
  "typed-builder",
  "walkdir",
 ]
@@ -479,12 +451,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "futures-core"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "gimli"
@@ -1010,9 +976,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.46.1"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "io-uring",
@@ -1032,30 +998,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-stream"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
-dependencies = [
- "futures-core",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-test"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
-dependencies = [
- "async-stream",
- "bytes",
- "futures-core",
- "tokio",
- "tokio-stream",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +156,12 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "bytes"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cast"
@@ -419,6 +447,7 @@ dependencies = [
  "itertools 0.14.0",
  "lazy-regex",
  "macro_rules_attribute",
+ "tokio-test",
  "typed-builder",
  "walkdir",
 ]
@@ -450,6 +479,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "gimli"
@@ -997,6 +1032,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
+dependencies = [
+ "async-stream",
+ "bytes",
+ "futures-core",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/bon-macros/Cargo.toml
+++ b/bon-macros/Cargo.toml
@@ -63,6 +63,9 @@ rustversion  = "1.0"
 [features]
 default = []
 
+alloc = []
+std   = []
+
 # See the docs on this feature in the `bon`'s crate `Cargo.toml`
 experimental-overwritable = []
 

--- a/bon-macros/src/builder/builder_gen/builder_derives/into_future.rs
+++ b/bon-macros/src/builder/builder_gen/builder_derives/into_future.rs
@@ -5,10 +5,15 @@ use crate::util::prelude::*;
 impl BuilderGenCtx {
     pub(super) fn derive_into_future(&self, config: &IntoFutureConfig) -> Result<TokenStream> {
         if self.finish_fn.asyncness.is_none() {
+            // While it is technically possible to call a synchronous function
+            // inside of the `IntoFuture::into_future()`, it's better force the
+            // user to mark the function as `async` explicitly. Otherwise it may
+            // indicate of some logic bug where the developer mistakenly marks
+            // a function that could be sync with `derive(IntoFuture)`.
             bail!(
                 &self.finish_fn.ident,
-                "`#[builder(derive(IntoFuture(...)))` can only be used with async functions \
-                because `IntoFuture::into_future()` method is an asynchronous method"
+                "`#[builder(derive(IntoFuture(...)))` can only be used with async functions; \
+                using it with a synchronous function is likely a mistake"
             );
         }
 

--- a/bon-macros/src/builder/builder_gen/builder_derives/into_future.rs
+++ b/bon-macros/src/builder/builder_gen/builder_derives/into_future.rs
@@ -7,7 +7,7 @@ impl BuilderGenCtx {
         if self.finish_fn.asyncness.is_none() {
             bail!(
                 &self.finish_fn.ident,
-                "`#[builder(derive(IntoFuture(...)))` can only be used with async functions
+                "`#[builder(derive(IntoFuture(...)))` can only be used with async functions \
                 because `IntoFuture::into_future()` method is an asynchronous method"
             );
         }

--- a/bon-macros/src/builder/builder_gen/builder_derives/into_future.rs
+++ b/bon-macros/src/builder/builder_gen/builder_derives/into_future.rs
@@ -1,6 +1,9 @@
 use crate::builder::builder_gen::models::BuilderGenCtx;
 use crate::builder::builder_gen::top_level_config::IntoFutureConfig;
 use crate::util::prelude::*;
+use std::borrow::Cow;
+use std::collections::BTreeSet;
+use syn::visit_mut::VisitMut;
 
 impl BuilderGenCtx {
     pub(super) fn derive_into_future(&self, config: &IntoFutureConfig) -> Result<TokenStream> {
@@ -33,25 +36,25 @@ impl BuilderGenCtx {
             );
         }
 
-        let output_ty = match &self.finish_fn.output {
-            syn::ReturnType::Default => Box::new(syn::Type::Tuple(syn::TypeTuple {
-                paren_token: syn::token::Paren::default(),
-                elems: syn::punctuated::Punctuated::new(),
-            })),
-            syn::ReturnType::Type(_, output_ty) => output_ty.clone(),
-        };
-
         let state_mod = &self.state_mod.ident;
-        let generics_decl = &self.generics.decl_without_defaults;
-        let generic_args = &self.generics.args;
         let builder_ident = &self.builder_type.ident;
         let state_var = &self.state_var;
         let finish_fn_ident = &self.finish_fn.ident;
         let box_ = &config.box_ident;
 
-        let builder_ty = quote! {
-            #builder_ident<#(#generic_args,)* #state_var>
-        };
+        let SignatureForIntoFuture {
+            generics_decl,
+            generic_args,
+            where_clause,
+            builder_lifetime,
+            output_ty,
+        } = self.signature_for_into_future();
+
+        let state_lifetime = builder_lifetime
+            .clone()
+            .unwrap_or_else(|| syn::Lifetime::new("'static", Span::call_site()));
+
+        let builder_lifetime = Option::into_iter(builder_lifetime);
 
         let send_bound = if config.is_send {
             quote! { + ::core::marker::Send }
@@ -77,13 +80,17 @@ impl BuilderGenCtx {
             #[automatically_derived]
             impl<
                 #(#generics_decl,)*
-                #state_var: #state_mod::IsComplete + 'static
+                #state_var: #state_mod::IsComplete + #state_lifetime
             >
-            ::core::future::IntoFuture for #builder_ty {
+            ::core::future::IntoFuture for #builder_ident<#(#generic_args,)* #state_var>
+            #where_clause
+            {
                 type Output = #output_ty;
                 type IntoFuture = ::core::pin::Pin<
                     #alloc::boxed::#box_<
-                        dyn ::core::future::Future<Output = #output_ty> #send_bound
+                        dyn ::core::future::Future<Output = Self::Output>
+                        #send_bound
+                        #(+ #builder_lifetime)*
                     >
                 >;
 
@@ -94,5 +101,115 @@ impl BuilderGenCtx {
         };
 
         Ok(tokens)
+    }
+
+    /// Handle the special case for a builder that captures lifetimes.
+    ///
+    /// Collapse all lifetimes into a single `'builder` lifetime. This is
+    /// because `dyn Trait` supports only a single `+ 'lifetime` bound.
+    fn signature_for_into_future(&self) -> SignatureForIntoFuture<'_> {
+        let generics_decl = &self.generics.decl_without_defaults;
+        let generic_args = &self.generics.args;
+        let where_clause = &self.generics.where_clause;
+
+        let output_ty = match &self.finish_fn.output {
+            syn::ReturnType::Default => Cow::Owned(syn::parse_quote!(())),
+            syn::ReturnType::Type(_, output_ty) => Cow::Borrowed(output_ty.as_ref()),
+        };
+
+        let contains_lifetimes = matches!(
+            self.generics.args.first(),
+            Some(syn::GenericArgument::Lifetime(_))
+        );
+
+        if !contains_lifetimes {
+            return SignatureForIntoFuture {
+                generics_decl: Cow::Borrowed(generics_decl),
+                generic_args: Cow::Borrowed(generic_args),
+                where_clause: where_clause.as_ref().map(Cow::Borrowed),
+                builder_lifetime: None,
+                output_ty,
+            };
+        }
+
+        let builder_lifetime = syn::Lifetime::new("'builder", Span::call_site());
+
+        let new_generic_args = generic_args
+            .iter()
+            .map(|arg| match arg {
+                syn::GenericArgument::Lifetime(_) => {
+                    syn::GenericArgument::Lifetime(builder_lifetime.clone())
+                }
+                _ => arg.clone(),
+            })
+            .collect::<Vec<_>>();
+
+        let mut original_lifetimes = BTreeSet::new();
+        let mut new_generics_decl = vec![syn::parse_quote!(#builder_lifetime)];
+
+        for param in generics_decl {
+            match param {
+                syn::GenericParam::Lifetime(lifetime) => {
+                    original_lifetimes.insert(&lifetime.lifetime.ident);
+                }
+                _ => {
+                    new_generics_decl.push(param.clone());
+                }
+            }
+        }
+
+        let mut replace_lifetimes = ReplaceLifetimes {
+            replacement: &builder_lifetime,
+            original_lifetimes: &original_lifetimes,
+        };
+
+        let mut new_where_clause = where_clause.clone();
+
+        if let Some(where_clause) = &mut new_where_clause {
+            replace_lifetimes.visit_where_clause_mut(where_clause);
+        }
+
+        let mut output_ty = output_ty.into_owned();
+
+        replace_lifetimes.visit_type_mut(&mut output_ty);
+
+        SignatureForIntoFuture {
+            generics_decl: Cow::Owned(new_generics_decl),
+            generic_args: Cow::Owned(new_generic_args),
+            where_clause: new_where_clause.map(Cow::Owned),
+            builder_lifetime: Some(builder_lifetime),
+            output_ty: Cow::Owned(output_ty),
+        }
+    }
+}
+
+struct SignatureForIntoFuture<'a> {
+    generics_decl: Cow<'a, [syn::GenericParam]>,
+    generic_args: Cow<'a, [syn::GenericArgument]>,
+    where_clause: Option<Cow<'a, syn::WhereClause>>,
+    builder_lifetime: Option<syn::Lifetime>,
+    output_ty: Cow<'a, syn::Type>,
+}
+
+struct ReplaceLifetimes<'a> {
+    replacement: &'a syn::Lifetime,
+    original_lifetimes: &'a BTreeSet<&'a syn::Ident>,
+}
+
+impl VisitMut for ReplaceLifetimes<'_> {
+    fn visit_lifetime_mut(&mut self, lifetime: &mut syn::Lifetime) {
+        if self.original_lifetimes.contains(&lifetime.ident) {
+            *lifetime = self.replacement.clone();
+        }
+    }
+
+    fn visit_item_mut(&mut self, _: &mut syn::Item) {
+        // Don't recurse into child items. They don't inherit the parent item's
+        // lifetimes.
+    }
+
+    fn visit_bound_lifetimes_mut(&mut self, _: &mut syn::BoundLifetimes) {
+        // Don't recurse into bound lifetime declarations. They introduce
+        // local lifetimes that we should keep as is
     }
 }

--- a/bon-macros/src/builder/builder_gen/builder_derives/into_future.rs
+++ b/bon-macros/src/builder/builder_gen/builder_derives/into_future.rs
@@ -1,0 +1,77 @@
+use crate::builder::builder_gen::models::BuilderGenCtx;
+use crate::builder::builder_gen::top_level_config::IntoFutureConfig;
+use crate::util::prelude::*;
+
+impl BuilderGenCtx {
+    pub(super) fn derive_into_future(&self, config: &IntoFutureConfig) -> Result<TokenStream> {
+        if self.finish_fn.asyncness.is_none() {
+            bail!(
+                &self.finish_fn.ident,
+                "`#[builder(derive(IntoFuture(...)))` can only be used with async functions
+                because `IntoFuture::into_future()` method is an asynchronous method"
+            );
+        }
+
+        if let Some(unsafety) = &self.finish_fn.unsafety {
+            bail!(
+                unsafety,
+                "`#[builder(derive(IntoFuture(...)))` is not supported for unsafe functions \
+                because `IntoFuture::into_future()` method is a safe method"
+            );
+        }
+
+        if let Some(arg) = self.finish_fn_args().next() {
+            bail!(
+                &arg.config.finish_fn.span(),
+                "`#[builder(derive(IntoFuture(...)))` is incompatible with `#[builder(finish_fn)]` members \
+                because `IntoFuture::into_future()` method accepts zero parameters"
+            );
+        }
+
+        let output_ty = match &self.finish_fn.output {
+            syn::ReturnType::Default => Box::new(syn::Type::Tuple(syn::TypeTuple {
+                paren_token: syn::token::Paren::default(),
+                elems: syn::punctuated::Punctuated::new(),
+            })),
+            syn::ReturnType::Type(_, output_ty) => output_ty.clone(),
+        };
+
+        let state_mod = &self.state_mod.ident;
+        let generics_decl = &self.generics.decl_without_defaults;
+        let generic_args = &self.generics.args;
+        let builder_ident = &self.builder_type.ident;
+        let state_var = &self.state_var;
+        let finish_fn_ident = &self.finish_fn.ident;
+
+        let builder_ty = quote! {
+            #builder_ident<#(#generic_args,)* #state_var>
+        };
+
+        let send_bound = if config.is_send {
+            quote! { + ::core::marker::Send }
+        } else {
+            quote! {}
+        };
+
+        let tokens = quote! {
+            #[automatically_derived]
+            impl<
+                #(#generics_decl,)*
+                #state_var: #state_mod::IsComplete + 'static
+            >
+            ::core::future::IntoFuture for #builder_ty
+            where
+                #builder_ty: 'static,
+            {
+                type Output = #output_ty;
+                type IntoFuture = ::std::pin::Pin<::std::boxed::Box<dyn ::core::future::Future<Output = #output_ty> #send_bound>>;
+
+                fn into_future(self) -> Self::IntoFuture {
+                    ::std::boxed::Box::pin(#builder_ident::#finish_fn_ident(self))
+                }
+            }
+        };
+
+        Ok(tokens)
+    }
+}

--- a/bon-macros/src/builder/builder_gen/builder_derives/mod.rs
+++ b/bon-macros/src/builder/builder_gen/builder_derives/mod.rs
@@ -1,6 +1,7 @@
 mod clone;
 mod debug;
 mod into;
+mod into_future;
 
 use super::top_level_config::{DeriveConfig, DerivesConfig};
 use super::BuilderGenCtx;
@@ -9,7 +10,7 @@ use darling::ast::GenericParamExt;
 
 impl BuilderGenCtx {
     pub(crate) fn builder_derives(&self) -> Result<TokenStream> {
-        let DerivesConfig { clone, debug, into } = &self.builder_type.derives;
+        let DerivesConfig { clone, debug, into, into_future } = &self.builder_type.derives;
 
         let mut tokens = TokenStream::new();
 
@@ -23,6 +24,10 @@ impl BuilderGenCtx {
 
         if into.is_present() {
             tokens.extend(self.derive_into()?);
+        }
+
+        if let Some(derive) = into_future {
+            tokens.extend(self.derive_into_future(derive)?);
         }
 
         Ok(tokens)

--- a/bon-macros/src/builder/builder_gen/builder_derives/mod.rs
+++ b/bon-macros/src/builder/builder_gen/builder_derives/mod.rs
@@ -10,7 +10,12 @@ use darling::ast::GenericParamExt;
 
 impl BuilderGenCtx {
     pub(crate) fn builder_derives(&self) -> Result<TokenStream> {
-        let DerivesConfig { clone, debug, into, into_future } = &self.builder_type.derives;
+        let DerivesConfig {
+            clone,
+            debug,
+            into,
+            into_future,
+        } = &self.builder_type.derives;
 
         let mut tokens = TokenStream::new();
 

--- a/bon-macros/src/builder/builder_gen/top_level_config/mod.rs
+++ b/bon-macros/src/builder/builder_gen/top_level_config/mod.rs
@@ -206,73 +206,64 @@ pub(crate) struct DeriveConfig {
 
 #[derive(Debug, Clone)]
 pub(crate) struct IntoFutureConfig {
+    pub(crate) box_ident: syn::Ident,
     pub(crate) is_send: bool,
 }
 
-impl Default for IntoFutureConfig {
-    fn default() -> Self {
-        Self { is_send: true }
+impl syn::parse::Parse for IntoFutureConfig {
+    fn parse(input: syn::parse::ParseStream<'_>) -> syn::Result<Self> {
+        // Parse "Box" as the required first argument.
+        let box_ident: syn::Ident = input.parse()?;
+        if box_ident != "Box" {
+            return Err(syn::Error::new(
+                box_ident.span(),
+                "expected `Box` as the first argument, only boxed futures are supported",
+            ));
+        }
+
+        // Check for optional ", ?Send" part.
+        let is_send = if input.peek(syn::Token![,]) {
+            input.parse::<syn::Token![,]>()?;
+
+            // Parse "?Send" as a single unit.
+            if input.peek(syn::Token![?]) {
+                input.parse::<syn::Token![?]>()?;
+                let send_ident: syn::Ident = input.parse()?;
+                if send_ident != "Send" {
+                    return Err(syn::Error::new(
+                        send_ident.span(),
+                        "expected `Send` after ?",
+                    ));
+                }
+                false
+            } else {
+                return Err(input.error("expected `?Send` as the second argument"));
+            }
+        } else {
+            true
+        };
+
+        // Ensure no trailing tokens.
+        if !input.is_empty() {
+            return Err(input.error("unexpected tokens after arguments"));
+        }
+
+        Ok(Self { box_ident, is_send })
     }
 }
 
 impl FromMeta for IntoFutureConfig {
     fn from_meta(meta: &syn::Meta) -> Result<Self> {
-        let meta_list = meta.require_list()?;
-        meta_list.require_parens_delim()?;
+        let meta = match meta {
+            syn::Meta::List(meta) => meta,
+            _ => bail!(meta, "expected an attribute of form `IntoFuture(Box, ...)`"),
+        };
 
-        // Use syn's Parse trait for cleaner parsing.
-        struct ParsedArguments {
-            is_send: bool,
-        }
+        meta.require_parens_delim()?;
 
-        impl syn::parse::Parse for ParsedArguments {
-            fn parse(input: syn::parse::ParseStream<'_>) -> syn::Result<Self> {
-                // Parse "Box" as the required first argument.
-                let box_ident: syn::Ident = input.parse()?;
-                if box_ident != "Box" {
-                    return Err(syn::Error::new(
-                        box_ident.span(),
-                        "expected `Box` as the first argument, only boxed futures are supported",
-                    ));
-                }
+        let me = syn::parse2(meta.tokens.clone())?;
 
-                // Check for optional ", ?Send" part.
-                let is_send = if input.peek(syn::Token![,]) {
-                    input.parse::<syn::Token![,]>()?;
-
-                    // Parse "?Send" as a single unit.
-                    if input.peek(syn::Token![?]) {
-                        input.parse::<syn::Token![?]>()?;
-                        let send_ident: syn::Ident = input.parse()?;
-                        if send_ident != "Send" {
-                            return Err(syn::Error::new(
-                                send_ident.span(),
-                                "expected `Send` after ?",
-                            ));
-                        }
-                        false
-                    } else {
-                        return Err(input.error("expected `?Send` as the second argument"));
-                    }
-                } else {
-                    true
-                };
-
-                // Ensure no trailing tokens.
-                if !input.is_empty() {
-                    return Err(input.error("unexpected tokens after arguments"));
-                }
-
-                Ok(ParsedArguments { is_send })
-            }
-        }
-
-        let parsed: ParsedArguments = syn::parse2(meta_list.tokens.clone())
-            .map_err(|err| Error::from(err).with_span(meta))?;
-
-        Ok(Self {
-            is_send: parsed.is_send,
-        })
+        Ok(me)
     }
 }
 

--- a/bon/Cargo.toml
+++ b/bon/Cargo.toml
@@ -61,9 +61,9 @@ macro_rules_attribute = "0.2"
 trybuild = "1.0.89"
 
 [features]
-alloc   = []
+alloc   = ["bon-macros/alloc"]
 default = ["std"]
-std     = ["alloc"]
+std     = ["bon-macros/std", "alloc"]
 
 # See the explanation of what this feature does in the docs here:
 # https://bon-rs.com/guide/typestate-api/custom-methods#implied-bounds

--- a/bon/src/__/ide.rs
+++ b/bon/src/__/ide.rs
@@ -101,6 +101,7 @@ pub mod builder_top_level {
         pub use core::convert::Into;
 
         /// See the docs at <https://bon-rs.com/reference/builder/top-level/derive>
+        #[rustversion::since(1.64)]
         pub use core::future::IntoFuture;
     }
 

--- a/bon/src/__/ide.rs
+++ b/bon/src/__/ide.rs
@@ -99,6 +99,9 @@ pub mod builder_top_level {
 
         /// See the docs at <https://bon-rs.com/reference/builder/top-level/derive>
         pub use core::convert::Into;
+
+        /// See the docs at <https://bon-rs.com/reference/builder/top-level/derive>
+        pub use core::future::IntoFuture;
     }
 
     /// The real name of this parameter is `crate` (without the underscore).

--- a/bon/tests/integration/builder/attr_into_future.rs
+++ b/bon/tests/integration/builder/attr_into_future.rs
@@ -1,0 +1,86 @@
+#[tokio::test]
+async fn into_future_basic() {
+    #[bon::builder]
+    #[builder(derive(IntoFuture(Box)))]
+    async fn simple_async_fn(value: u32) -> u32 {
+        value * 2
+    }
+
+    // Test direct call.
+    let result = simple_async_fn().value(21).call().await;
+    assert_eq!(result, 42);
+
+    // Test using IntoFuture with await.
+    let result = simple_async_fn().value(21).await;
+    assert_eq!(result, 42);
+}
+
+#[tokio::test]
+async fn into_future_non_send() {
+    #[bon::builder]
+    #[builder(derive(IntoFuture(Box, ?Send)))]
+    async fn non_send_async_fn(value: u32) -> u32 {
+        // This future can be !Send.
+        value * 2
+    }
+
+    // Test with non-Send future.
+    let result = non_send_async_fn().value(21).await;
+    assert_eq!(result, 42);
+}
+
+#[tokio::test]
+async fn into_future_with_result() {
+    #[bon::builder]
+    #[builder(derive(IntoFuture(Box)))]
+    async fn async_with_result(value: u32) -> Result<u32, String> {
+        if value > 0 {
+            Ok(value * 2)
+        } else {
+            Err("Value must be positive".to_string())
+        }
+    }
+
+    // Test successful case.
+    let result = async_with_result().value(21).await;
+    assert_eq!(result.unwrap(), 42);
+
+    // Test error case.
+    let result = async_with_result().value(0).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn into_future_with_impl() {
+    struct Calculator;
+
+    #[bon::bon]
+    impl Calculator {
+        #[builder]
+        #[builder(derive(IntoFuture(Box)))]
+        async fn multiply(a: u32, b: u32) -> u32 {
+            a * b
+        }
+    }
+
+    // Test using IntoFuture on impl method.
+    let result = Calculator::multiply().a(6).b(7).await;
+    assert_eq!(result, 42);
+}
+
+#[tokio::test]
+async fn into_future_with_optional() {
+    #[bon::builder]
+    #[builder(derive(IntoFuture(Box)))]
+    async fn optional_param(#[builder(default = 100)] value: u32) -> u32 {
+        value
+    }
+
+    // Test with value.
+    let result = optional_param().value(42).await;
+    assert_eq!(result, 42);
+
+    // Test without value (using default).
+    let result = optional_param().await;
+    assert_eq!(result, 100);
+}

--- a/bon/tests/integration/builder/attr_into_future.rs
+++ b/bon/tests/integration/builder/attr_into_future.rs
@@ -2,7 +2,6 @@ use crate::prelude::*;
 
 #[tokio::test]
 async fn into_future_basic() {
-    #[builder]
     #[builder(derive(IntoFuture(Box)))]
     async fn simple_async_fn(value: u32) -> u32 {
         value * 2
@@ -19,7 +18,6 @@ async fn into_future_basic() {
 
 #[tokio::test]
 async fn into_future_non_send() {
-    #[builder]
     #[builder(derive(IntoFuture(Box, ?Send)))]
     async fn non_send_async_fn(value: u32) -> u32 {
         // This future can be !Send.
@@ -33,7 +31,6 @@ async fn into_future_non_send() {
 
 #[tokio::test]
 async fn into_future_with_result() {
-    #[builder]
     #[builder(derive(IntoFuture(Box)))]
     async fn async_with_result(value: u32) -> Result<u32, String> {
         if value > 0 {
@@ -72,7 +69,6 @@ async fn into_future_with_impl() {
 
 #[tokio::test]
 async fn into_future_with_optional() {
-    #[builder]
     #[builder(derive(IntoFuture(Box)))]
     async fn optional_param(#[builder(default = 100)] value: u32) -> u32 {
         value

--- a/bon/tests/integration/builder/attr_into_future.rs
+++ b/bon/tests/integration/builder/attr_into_future.rs
@@ -32,11 +32,11 @@ async fn into_future_non_send() {
 #[tokio::test]
 async fn into_future_with_result() {
     #[builder(derive(IntoFuture(Box)))]
-    async fn async_with_result(value: u32) -> Result<u32, String> {
+    async fn async_with_result(value: u32) -> Result<u32, &'static str> {
         if value > 0 {
             Ok(value * 2)
         } else {
-            Err("Value must be positive".to_string())
+            Err("Value must be positive")
         }
     }
 

--- a/bon/tests/integration/builder/attr_into_future.rs
+++ b/bon/tests/integration/builder/attr_into_future.rs
@@ -1,6 +1,8 @@
+use crate::prelude::*;
+
 #[tokio::test]
 async fn into_future_basic() {
-    #[bon::builder]
+    #[builder]
     #[builder(derive(IntoFuture(Box)))]
     async fn simple_async_fn(value: u32) -> u32 {
         value * 2
@@ -17,7 +19,7 @@ async fn into_future_basic() {
 
 #[tokio::test]
 async fn into_future_non_send() {
-    #[bon::builder]
+    #[builder]
     #[builder(derive(IntoFuture(Box, ?Send)))]
     async fn non_send_async_fn(value: u32) -> u32 {
         // This future can be !Send.
@@ -31,7 +33,7 @@ async fn into_future_non_send() {
 
 #[tokio::test]
 async fn into_future_with_result() {
-    #[bon::builder]
+    #[builder]
     #[builder(derive(IntoFuture(Box)))]
     async fn async_with_result(value: u32) -> Result<u32, String> {
         if value > 0 {
@@ -54,7 +56,7 @@ async fn into_future_with_result() {
 async fn into_future_with_impl() {
     struct Calculator;
 
-    #[bon::bon]
+    #[bon]
     impl Calculator {
         #[builder]
         #[builder(derive(IntoFuture(Box)))]
@@ -70,7 +72,7 @@ async fn into_future_with_impl() {
 
 #[tokio::test]
 async fn into_future_with_optional() {
-    #[bon::builder]
+    #[builder]
     #[builder(derive(IntoFuture(Box)))]
     async fn optional_param(#[builder(default = 100)] value: u32) -> u32 {
         value

--- a/bon/tests/integration/builder/attr_into_future.rs
+++ b/bon/tests/integration/builder/attr_into_future.rs
@@ -1,132 +1,257 @@
-use crate::prelude::*;
-use core::future::ready;
+/// [`core::future::IntoFuture`] relies on [`Box`]. Also this trait was
+/// introduced in Rust 1.64, while `bon`'s MSRV is 1.59 at the time of this
+/// writing.
+#[cfg(any(feature = "std", feature = "alloc"))]
+#[rustversion::since(1.64)]
+mod tests {
+    use crate::prelude::*;
+    use core::future::{ready, IntoFuture};
+    use core::marker::PhantomData;
 
-#[tokio::test]
-async fn into_future_basic() {
-    #[builder(derive(IntoFuture(Box)))]
-    async fn simple_async_fn(value: u32) -> u32 {
-        ready(value * 2).await
+    async fn assert_send<B>(builder: B) -> B::Output
+    where
+        B: IntoFuture + Send,
+        B::IntoFuture: Send,
+    {
+        #[expect(clippy::incompatible_msrv)]
+        let fut = builder.into_future();
+        let _: &dyn Send = &fut;
+        fut.await
     }
 
-    // Test direct call.
-    let result = simple_async_fn().value(21).call().await;
-    assert_eq!(result, 42);
+    #[expect(clippy::future_not_send)]
+    async fn non_send_future() {
+        // By keeping `Rc` across an await point, we force the compiler to store it
+        // as part of the future's state machine struct and thus we make it non-Send
+        let non_send = PhantomData::<Rc<()>>;
 
-    // Test using IntoFuture with await.
-    let result = simple_async_fn().value(21).await;
-    assert_eq!(result, 42);
-}
+        ready(()).await;
 
-#[tokio::test]
-async fn into_future_non_send() {
-    #[builder(derive(IntoFuture(Box, ?Send)))]
-    async fn non_send_async_fn(value: u32) -> u32 {
-        // This future can be !Send.
-        ready(value * 2).await
+        let _ = &non_send;
     }
 
-    // Test with non-Send future.
-    let result = non_send_async_fn().value(21).await;
-    assert_eq!(result, 42);
-}
+    mod test_fn {
+        use super::*;
 
-#[tokio::test]
-async fn into_future_with_result() {
-    #[builder(derive(IntoFuture(Box)))]
-    async fn async_with_result(value: u32) -> Result<u32, &'static str> {
-        ready(if value > 0 {
-            Ok(value * 2)
-        } else {
-            Err("Value must be positive")
-        })
-        .await
-    }
+        #[tokio::test]
+        async fn basic() {
+            #[builder(derive(IntoFuture(Box)))]
+            async fn simple_async_fn(value: u32) -> u32 {
+                ready(value * 2).await
+            }
 
-    // Test successful case.
-    let result = async_with_result().value(21).await;
-    assert_eq!(result.unwrap(), 42);
+            // Test direct call.
+            let builder = simple_async_fn().value(21).call();
+            assert_eq!(assert_send(builder).await, 42);
 
-    // Test error case.
-    let result = async_with_result().value(0).await;
-    result.unwrap_err();
-}
+            // Test using IntoFuture with await.
+            let builder = simple_async_fn().value(21);
+            assert_eq!(assert_send(builder).await, 42);
+        }
 
-#[tokio::test]
-async fn into_future_with_impl() {
-    struct Calculator;
+        #[tokio::test]
+        async fn non_send() {
+            #[builder(derive(IntoFuture(Box, ?Send)))]
+            #[expect(clippy::future_not_send)]
+            async fn non_send_async_fn(value: u32) -> u32 {
+                non_send_future().await;
+                // This future can be !Send.
+                ready(value * 2).await
+            }
 
-    #[bon]
-    impl Calculator {
-        #[builder]
-        #[builder(derive(IntoFuture(Box)))]
-        async fn multiply(a: u32, b: u32) -> u32 {
-            ready(a * b).await
+            // Test with non-Send future.
+            let result = non_send_async_fn().value(21).await;
+
+            assert_eq!(result, 42);
+        }
+
+        #[tokio::test]
+        async fn result() {
+            #[builder(derive(IntoFuture(Box)))]
+            async fn async_with_result(value: u32) -> Result<u32, &'static str> {
+                ready(if value > 0 {
+                    Ok(value * 2)
+                } else {
+                    Err("Value must be positive")
+                })
+                .await
+            }
+
+            // Test successful case.
+            let builder = async_with_result().value(21);
+            assert_eq!(assert_send(builder).await.unwrap(), 42);
+
+            // Test error case.
+            let builder = async_with_result().value(0);
+
+            assert_send(builder).await.unwrap_err();
+        }
+
+        #[tokio::test]
+        async fn into_future_with_optional() {
+            #[builder(derive(IntoFuture(Box)))]
+            async fn optional_param(#[builder(default = 100)] value: u32) -> u32 {
+                ready(value).await
+            }
+
+            // Test with value.
+            let builder = optional_param().value(42);
+            assert_eq!(assert_send(builder).await, 42);
+
+            // Test without value (using default).
+            let builder = optional_param();
+            assert_eq!(assert_send(builder).await, 100);
+        }
+
+        #[tokio::test]
+        async fn references_in_params() {
+            struct Dummy;
+
+            #[builder(derive(IntoFuture(Box)))]
+            async fn sut<'named1, 'named2>(
+                _x1: &Dummy,
+                _x2: &Dummy,
+                x3: &'named1 Dummy,
+                x4: &'named2 Dummy,
+            ) -> &'named2 Dummy {
+                let _: &'named1 Dummy = x3;
+                ready(x4).await
+            }
+
+            // Store the dummy struct in local variables to make sure no `'static`
+            // lifetime promotion happens
+            let local_x1 = Dummy;
+            let local_x2 = Dummy;
+            let local_x3 = Dummy;
+            let local_x4 = Dummy;
+
+            let builder = sut()
+                .x1(&local_x1)
+                .x2(&local_x2)
+                .x3(&local_x3)
+                .x4(&local_x4);
+
+            let &Dummy = assert_send(builder).await;
+        }
+
+        #[tokio::test]
+        async fn anon_lifetime_in_return_type() {
+            struct Dummy;
+
+            #[builder(derive(IntoFuture(Box)))]
+            async fn sut(x1: &Dummy) -> &Dummy {
+                ready(x1).await
+            }
+
+            // Store the dummy struct in local variables to make sure no `'static`
+            // lifetime promotion happens
+            let local_x1 = Dummy;
+
+            let builder = sut().x1(&local_x1);
+
+            let &Dummy = assert_send(builder).await;
         }
     }
 
-    // Test using IntoFuture on impl method.
-    let result = Calculator::multiply().a(6).b(7).await;
-    assert_eq!(result, 42);
-}
+    mod test_method {
+        use super::*;
 
-#[tokio::test]
-async fn into_future_with_optional() {
-    #[builder(derive(IntoFuture(Box)))]
-    async fn optional_param(#[builder(default = 100)] value: u32) -> u32 {
-        ready(value).await
+        #[tokio::test]
+        async fn basic() {
+            struct Calculator;
+
+            #[bon]
+            impl Calculator {
+                #[builder]
+                #[builder(derive(IntoFuture(Box)))]
+                async fn multiply(a: u32, b: u32) -> u32 {
+                    ready(a * b).await
+                }
+            }
+
+            // Test using IntoFuture on impl method.
+            let builder = Calculator::multiply().a(6).b(7);
+            assert_eq!(assert_send(builder).await, 42);
+        }
+
+        #[tokio::test]
+        async fn non_send() {
+            struct Sut;
+
+            #[bon]
+            impl Sut {
+                #[builder(derive(IntoFuture(Box, ?Send)))]
+                #[expect(clippy::future_not_send)]
+                async fn sut(self, value: u32) -> u32 {
+                    non_send_future().await;
+
+                    // This future can be !Send.
+                    ready(value * 2).await
+                }
+            }
+
+            // Test with non-Send future.
+            let result = Sut.sut().value(21).await;
+            assert_eq!(result, 42);
+        }
+
+        #[tokio::test]
+        async fn references_in_params() {
+            struct Dummy;
+
+            #[bon]
+            impl Dummy {
+                #[builder(derive(IntoFuture(Box)))]
+                async fn sut<'named1, 'named2>(
+                    &self,
+                    _x1: &Self,
+                    _x2: &Self,
+                    x3: &'named1 Self,
+                    x4: &'named2 Self,
+                ) -> &'named2 Self {
+                    let _: &'named1 Self = x3;
+                    ready(x4).await
+                }
+            }
+
+            // Store the dummy struct in local variables to make sure no `'static`
+            // lifetime promotion happens
+            let local_self = Dummy;
+            let local_x1 = Dummy;
+            let local_x2 = Dummy;
+            let local_x3 = Dummy;
+            let local_x4 = Dummy;
+
+            let builder = local_self
+                .sut()
+                .x1(&local_x1)
+                .x2(&local_x2)
+                .x3(&local_x3)
+                .x4(&local_x4);
+
+            let _: &Dummy = assert_send(builder).await;
+        }
+
+        #[tokio::test]
+        async fn anon_lifetime_in_return_type() {
+            struct Dummy;
+
+            #[bon]
+            impl Dummy {
+                #[builder(derive(IntoFuture(Box)))]
+                async fn sut(&self, _x1: &Self) -> &Self {
+                    ready(self).await
+                }
+            }
+
+            // Store the dummy struct in local variables to make sure no `'static`
+            // lifetime promotion happens
+            let local_self = Dummy;
+            let local_x1 = Dummy;
+
+            let builder = local_self.sut().x1(&local_x1);
+
+            let _: &Dummy = assert_send(builder).await;
+        }
     }
-
-    // Test with value.
-    let result = optional_param().value(42).await;
-    assert_eq!(result, 42);
-
-    // Test without value (using default).
-    let result = optional_param().await;
-    assert_eq!(result, 100);
-}
-
-#[tokio::test]
-async fn references_in_params() {
-    struct Dummy;
-
-    #[builder(derive(IntoFuture(Box)))]
-    async fn sut<'named1, 'named2>(
-        _x1: &Dummy,
-        _x2: &Dummy,
-        x3: &'named1 Dummy,
-        x4: &'named2 Dummy,
-    ) -> &'named2 Dummy {
-        let _: &'named1 Dummy = x3;
-        ready(x4).await
-    }
-
-    // Store the dummy struct in local variables to make sure no `'static`
-    // lifetime promotion happens
-    let local_x1 = Dummy;
-    let local_x2 = Dummy;
-    let local_x3 = Dummy;
-    let local_x4 = Dummy;
-
-    let _: &Dummy = sut()
-        .x1(&local_x1)
-        .x2(&local_x2)
-        .x3(&local_x3)
-        .x4(&local_x4)
-        .await;
-}
-
-#[tokio::test]
-async fn anon_lifetime_in_return_type() {
-    struct Dummy;
-
-    #[builder(derive(IntoFuture(Box)))]
-    async fn sut(x1: &Dummy) -> &Dummy {
-        ready(x1).await
-    }
-
-    // Store the dummy struct in local variables to make sure no `'static`
-    // lifetime promotion happens
-    let local_x1 = Dummy;
-
-    let _: &Dummy = sut().x1(&local_x1).await;
 }

--- a/bon/tests/integration/builder/attr_into_future.rs
+++ b/bon/tests/integration/builder/attr_into_future.rs
@@ -84,3 +84,49 @@ async fn into_future_with_optional() {
     let result = optional_param().await;
     assert_eq!(result, 100);
 }
+
+#[tokio::test]
+async fn references_in_params() {
+    struct Dummy;
+
+    #[builder(derive(IntoFuture(Box)))]
+    async fn sut<'named1, 'named2>(
+        _x1: &Dummy,
+        _x2: &Dummy,
+        x3: &'named1 Dummy,
+        x4: &'named2 Dummy,
+    ) -> &'named2 Dummy {
+        let _: &'named1 Dummy = x3;
+        ready(x4).await
+    }
+
+    // Store the dummy struct in local variables to make sure no `'static`
+    // lifetime promotion happens
+    let local_x1 = Dummy;
+    let local_x2 = Dummy;
+    let local_x3 = Dummy;
+    let local_x4 = Dummy;
+
+    let _: &Dummy = sut()
+        .x1(&local_x1)
+        .x2(&local_x2)
+        .x3(&local_x3)
+        .x4(&local_x4)
+        .await;
+}
+
+#[tokio::test]
+async fn anon_lifetime_in_return_type() {
+    struct Dummy;
+
+    #[builder(derive(IntoFuture(Box)))]
+    async fn sut(x1: &Dummy) -> &Dummy {
+        ready(x1).await
+    }
+
+    // Store the dummy struct in local variables to make sure no `'static`
+    // lifetime promotion happens
+    let local_x1 = Dummy;
+
+    let _: &Dummy = sut().x1(&local_x1).await;
+}

--- a/bon/tests/integration/builder/mod.rs
+++ b/bon/tests/integration/builder/mod.rs
@@ -7,6 +7,7 @@ mod attr_derive;
 mod attr_field;
 mod attr_getter;
 mod attr_into;
+mod attr_into_future;
 mod attr_on;
 mod attr_overwritable;
 mod attr_required;

--- a/bon/tests/integration/builder/mod.rs
+++ b/bon/tests/integration/builder/mod.rs
@@ -7,7 +7,6 @@ mod attr_derive;
 mod attr_field;
 mod attr_getter;
 mod attr_into;
-mod attr_into_future;
 mod attr_on;
 mod attr_overwritable;
 mod attr_required;
@@ -30,6 +29,10 @@ mod target_feature;
 mod track_caller;
 
 use crate::prelude::*;
+
+/// [`core::future::IntoFuture`] relies on [`Box`]
+#[cfg(any(feature = "std", feature = "alloc"))]
+mod attr_into_future;
 
 #[test]
 fn leading_underscore_is_stripped() {

--- a/bon/tests/integration/builder/mod.rs
+++ b/bon/tests/integration/builder/mod.rs
@@ -7,6 +7,7 @@ mod attr_derive;
 mod attr_field;
 mod attr_getter;
 mod attr_into;
+mod attr_into_future;
 mod attr_on;
 mod attr_overwritable;
 mod attr_required;
@@ -29,10 +30,6 @@ mod target_feature;
 mod track_caller;
 
 use crate::prelude::*;
-
-/// [`core::future::IntoFuture`] relies on [`Box`]
-#[cfg(any(feature = "std", feature = "alloc"))]
-mod attr_into_future;
 
 #[test]
 fn leading_underscore_is_stripped() {

--- a/bon/tests/integration/ui/compile_fail/attr_into_future.rs
+++ b/bon/tests/integration/ui/compile_fail/attr_into_future.rs
@@ -1,5 +1,4 @@
-use bon::{bon, builder, Builder};
-use core::future::IntoFuture;
+use bon::{builder, Builder};
 
 // IntoFuture can only be used with async functions
 #[builder(derive(IntoFuture(Box)))]
@@ -42,29 +41,6 @@ async fn wrong_send_syntax() -> u32 {
 #[builder(derive(IntoFuture(Box)))]
 struct AsyncConfig {
     value: u32,
-}
-
-fn _non_send() {
-    struct Sut;
-
-    fn assert_send(_: &dyn Send) {}
-
-    #[bon]
-    impl Sut {
-        #[builder(derive(IntoFuture(Box, ?Send)))]
-        async fn sut(&self, value: u32) -> u32 {
-            value * 2
-        }
-    }
-
-    assert_send(&Sut.sut().value(21).into_future());
-
-    #[builder(derive(IntoFuture(Box, ?Send)))]
-    async fn sut(value: u32) -> u32 {
-        value * 2
-    }
-
-    assert_send(&sut().value(21).into_future());
 }
 
 fn main() {}

--- a/bon/tests/integration/ui/compile_fail/attr_into_future.rs
+++ b/bon/tests/integration/ui/compile_fail/attr_into_future.rs
@@ -1,0 +1,54 @@
+// IntoFuture can only be used with async functions
+#[bon::builder]
+#[builder(derive(IntoFuture(Box)))]
+fn sync_function() -> u32 {
+    42
+}
+
+// IntoFuture is not supported for unsafe functions
+#[bon::builder]
+#[builder(derive(IntoFuture(Box)))]
+async unsafe fn unsafe_async_function() -> u32 {
+    42
+}
+
+// IntoFuture is incompatible with finish_fn members
+#[bon::builder]
+#[builder(derive(IntoFuture(Box)))]
+async fn with_finish_fn(
+    #[builder(finish_fn)] value: u32
+) -> u32 {
+    value
+}
+
+// IntoFuture requires Box argument
+#[bon::builder]
+#[builder(derive(IntoFuture))]
+async fn missing_box_arg() -> u32 {
+    42
+}
+
+// Only Box is supported as future container
+#[bon::builder]
+#[builder(derive(IntoFuture(Arc)))]
+async fn wrong_container() -> u32 {
+    42
+}
+
+// Wrong syntax for ?Send
+#[bon::builder]
+#[builder(derive(IntoFuture(Box, Send)))]
+async fn wrong_send_syntax() -> u32 {
+    42
+}
+
+use bon::Builder;
+
+// Cannot be used on structs
+#[derive(Builder)]
+#[builder(derive(IntoFuture(Box)))]
+struct AsyncConfig {
+    value: u32,
+}
+
+fn main() {}

--- a/bon/tests/integration/ui/compile_fail/attr_into_future.rs
+++ b/bon/tests/integration/ui/compile_fail/attr_into_future.rs
@@ -2,42 +2,36 @@ use bon::{bon, builder, Builder};
 use core::future::IntoFuture;
 
 // IntoFuture can only be used with async functions
-#[bon::builder]
 #[builder(derive(IntoFuture(Box)))]
 fn sync_function() -> u32 {
     42
 }
 
 // IntoFuture is not supported for unsafe functions
-#[bon::builder]
 #[builder(derive(IntoFuture(Box)))]
 async unsafe fn unsafe_async_function() -> u32 {
     42
 }
 
 // IntoFuture is incompatible with finish_fn members
-#[bon::builder]
 #[builder(derive(IntoFuture(Box)))]
 async fn with_finish_fn(#[builder(finish_fn)] value: u32) -> u32 {
     value
 }
 
 // IntoFuture requires Box argument
-#[bon::builder]
 #[builder(derive(IntoFuture))]
 async fn missing_box_arg() -> u32 {
     42
 }
 
 // Only Box is supported as future container
-#[bon::builder]
 #[builder(derive(IntoFuture(Arc)))]
 async fn wrong_container() -> u32 {
     42
 }
 
 // Wrong syntax for ?Send
-#[bon::builder]
 #[builder(derive(IntoFuture(Box, Send)))]
 async fn wrong_send_syntax() -> u32 {
     42

--- a/bon/tests/integration/ui/compile_fail/attr_into_future.stderr
+++ b/bon/tests/integration/ui/compile_fail/attr_into_future.stderr
@@ -18,7 +18,7 @@ error: `#[builder(derive(IntoFuture(...)))` is incompatible with `#[builder(fini
 19 |     #[builder(finish_fn)] value: u32
    |               ^^^^^^^^^
 
-error: expected attribute arguments in parentheses: `IntoFuture(...)`
+error: expected an attribute of form `IntoFuture(Box, ...)`
   --> tests/integration/ui/compile_fail/attr_into_future.rs:26:18
    |
 26 | #[builder(derive(IntoFuture))]

--- a/bon/tests/integration/ui/compile_fail/attr_into_future.stderr
+++ b/bon/tests/integration/ui/compile_fail/attr_into_future.stderr
@@ -1,51 +1,51 @@
 error: `#[builder(derive(IntoFuture(...)))` can only be used with async functions; using it with a synchronous function is likely a mistake
  --> tests/integration/ui/compile_fail/attr_into_future.rs:5:1
   |
-5 | #[bon::builder]
-  | ^^^^^^^^^^^^^^^
+5 | #[builder(derive(IntoFuture(Box)))]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
-  = note: this error originates in the attribute macro `bon::builder` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the attribute macro `builder` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `#[builder(derive(IntoFuture(...)))` is not supported for unsafe functions because `IntoFuture::into_future()` method is a safe method
-  --> tests/integration/ui/compile_fail/attr_into_future.rs:14:7
+  --> tests/integration/ui/compile_fail/attr_into_future.rs:12:7
    |
-14 | async unsafe fn unsafe_async_function() -> u32 {
+12 | async unsafe fn unsafe_async_function() -> u32 {
    |       ^^^^^^
 
 error: `#[builder(derive(IntoFuture(...)))` is incompatible with `#[builder(finish_fn)]` members because `IntoFuture::into_future()` method accepts zero parameters
-  --> tests/integration/ui/compile_fail/attr_into_future.rs:21:35
+  --> tests/integration/ui/compile_fail/attr_into_future.rs:18:35
    |
-21 | async fn with_finish_fn(#[builder(finish_fn)] value: u32) -> u32 {
+18 | async fn with_finish_fn(#[builder(finish_fn)] value: u32) -> u32 {
    |                                   ^^^^^^^^^
 
 error: expected an attribute of form `IntoFuture(Box, ...)`
-  --> tests/integration/ui/compile_fail/attr_into_future.rs:27:18
+  --> tests/integration/ui/compile_fail/attr_into_future.rs:23:18
    |
-27 | #[builder(derive(IntoFuture))]
+23 | #[builder(derive(IntoFuture))]
    |                  ^^^^^^^^^^
 
 error: expected `Box` as the first argument, only boxed futures are supported
-  --> tests/integration/ui/compile_fail/attr_into_future.rs:34:29
+  --> tests/integration/ui/compile_fail/attr_into_future.rs:29:29
    |
-34 | #[builder(derive(IntoFuture(Arc)))]
+29 | #[builder(derive(IntoFuture(Arc)))]
    |                             ^^^
 
 error: expected `?Send` as the second argument
-  --> tests/integration/ui/compile_fail/attr_into_future.rs:41:34
+  --> tests/integration/ui/compile_fail/attr_into_future.rs:35:34
    |
-41 | #[builder(derive(IntoFuture(Box, Send)))]
+35 | #[builder(derive(IntoFuture(Box, Send)))]
    |                                  ^^^^
 
 error: `#[builder(derive(IntoFuture(...)))` can only be used with async functions; using it with a synchronous function is likely a mistake
-  --> tests/integration/ui/compile_fail/attr_into_future.rs:49:8
+  --> tests/integration/ui/compile_fail/attr_into_future.rs:43:8
    |
-49 | struct AsyncConfig {
+43 | struct AsyncConfig {
    |        ^^^^^^^^^^^
 
 error[E0277]: `dyn Future<Output = u32>` cannot be sent between threads safely
-  --> tests/integration/ui/compile_fail/attr_into_future.rs:66:17
+  --> tests/integration/ui/compile_fail/attr_into_future.rs:60:17
    |
-66 |     assert_send(&Sut.sut().value(21).into_future());
+60 |     assert_send(&Sut.sut().value(21).into_future());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `dyn Future<Output = u32>` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `dyn Future<Output = u32>`
@@ -63,9 +63,9 @@ note: required because it appears within the type `Pin<Box<dyn Future<Output = u
    = note: required for the cast from `&Pin<Box<dyn Future<Output = u32>>>` to `&dyn Send`
 
 error[E0277]: `(dyn Future<Output = u32> + 'static)` cannot be sent between threads safely
-  --> tests/integration/ui/compile_fail/attr_into_future.rs:73:17
+  --> tests/integration/ui/compile_fail/attr_into_future.rs:67:17
    |
-73 |     assert_send(&sut().value(21).into_future());
+67 |     assert_send(&sut().value(21).into_future());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Future<Output = u32> + 'static)` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `(dyn Future<Output = u32> + 'static)`

--- a/bon/tests/integration/ui/compile_fail/attr_into_future.stderr
+++ b/bon/tests/integration/ui/compile_fail/attr_into_future.stderr
@@ -1,5 +1,4 @@
-error: `#[builder(derive(IntoFuture(...)))` can only be used with async functions
-                       because `IntoFuture::into_future()` method is an asynchronous method
+error: `#[builder(derive(IntoFuture(...)))` can only be used with async functions because `IntoFuture::into_future()` method is an asynchronous method
  --> tests/integration/ui/compile_fail/attr_into_future.rs:2:1
   |
 2 | #[bon::builder]
@@ -37,8 +36,7 @@ error: expected `?Send` as the second argument
 40 | #[builder(derive(IntoFuture(Box, Send)))]
    |                                  ^^^^
 
-error: `#[builder(derive(IntoFuture(...)))` can only be used with async functions
-                       because `IntoFuture::into_future()` method is an asynchronous method
+error: `#[builder(derive(IntoFuture(...)))` can only be used with async functions because `IntoFuture::into_future()` method is an asynchronous method
   --> tests/integration/ui/compile_fail/attr_into_future.rs:50:8
    |
 50 | struct AsyncConfig {

--- a/bon/tests/integration/ui/compile_fail/attr_into_future.stderr
+++ b/bon/tests/integration/ui/compile_fail/attr_into_future.stderr
@@ -1,83 +1,43 @@
 error: `#[builder(derive(IntoFuture(...)))` can only be used with async functions; using it with a synchronous function is likely a mistake
- --> tests/integration/ui/compile_fail/attr_into_future.rs:5:1
+ --> tests/integration/ui/compile_fail/attr_into_future.rs:4:1
   |
-5 | #[builder(derive(IntoFuture(Box)))]
+4 | #[builder(derive(IntoFuture(Box)))]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in the attribute macro `builder` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `#[builder(derive(IntoFuture(...)))` is not supported for unsafe functions because `IntoFuture::into_future()` method is a safe method
-  --> tests/integration/ui/compile_fail/attr_into_future.rs:12:7
+  --> tests/integration/ui/compile_fail/attr_into_future.rs:11:7
    |
-12 | async unsafe fn unsafe_async_function() -> u32 {
+11 | async unsafe fn unsafe_async_function() -> u32 {
    |       ^^^^^^
 
 error: `#[builder(derive(IntoFuture(...)))` is incompatible with `#[builder(finish_fn)]` members because `IntoFuture::into_future()` method accepts zero parameters
-  --> tests/integration/ui/compile_fail/attr_into_future.rs:18:35
+  --> tests/integration/ui/compile_fail/attr_into_future.rs:17:35
    |
-18 | async fn with_finish_fn(#[builder(finish_fn)] value: u32) -> u32 {
+17 | async fn with_finish_fn(#[builder(finish_fn)] value: u32) -> u32 {
    |                                   ^^^^^^^^^
 
 error: expected an attribute of form `IntoFuture(Box, ...)`
-  --> tests/integration/ui/compile_fail/attr_into_future.rs:23:18
+  --> tests/integration/ui/compile_fail/attr_into_future.rs:22:18
    |
-23 | #[builder(derive(IntoFuture))]
+22 | #[builder(derive(IntoFuture))]
    |                  ^^^^^^^^^^
 
 error: expected `Box` as the first argument, only boxed futures are supported
-  --> tests/integration/ui/compile_fail/attr_into_future.rs:29:29
+  --> tests/integration/ui/compile_fail/attr_into_future.rs:28:29
    |
-29 | #[builder(derive(IntoFuture(Arc)))]
+28 | #[builder(derive(IntoFuture(Arc)))]
    |                             ^^^
 
 error: expected `?Send` as the second argument
-  --> tests/integration/ui/compile_fail/attr_into_future.rs:35:34
+  --> tests/integration/ui/compile_fail/attr_into_future.rs:34:34
    |
-35 | #[builder(derive(IntoFuture(Box, Send)))]
+34 | #[builder(derive(IntoFuture(Box, Send)))]
    |                                  ^^^^
 
 error: `#[builder(derive(IntoFuture(...)))` can only be used with async functions; using it with a synchronous function is likely a mistake
-  --> tests/integration/ui/compile_fail/attr_into_future.rs:43:8
+  --> tests/integration/ui/compile_fail/attr_into_future.rs:42:8
    |
-43 | struct AsyncConfig {
+42 | struct AsyncConfig {
    |        ^^^^^^^^^^^
-
-error[E0277]: `dyn Future<Output = u32>` cannot be sent between threads safely
-  --> tests/integration/ui/compile_fail/attr_into_future.rs:60:17
-   |
-60 |     assert_send(&Sut.sut().value(21).into_future());
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `dyn Future<Output = u32>` cannot be sent between threads safely
-   |
-   = help: the trait `Send` is not implemented for `dyn Future<Output = u32>`
-   = note: required for `Unique<dyn Future<Output = u32>>` to implement `Send`
-note: required because it appears within the type `Box<dyn Future<Output = u32>>`
-  --> $RUST/alloc/src/boxed.rs
-   |
-   | pub struct Box<
-   |            ^^^
-note: required because it appears within the type `Pin<Box<dyn Future<Output = u32>>>`
-  --> $RUST/core/src/pin.rs
-   |
-   | pub struct Pin<Ptr> {
-   |            ^^^
-   = note: required for the cast from `&Pin<Box<dyn Future<Output = u32>>>` to `&dyn Send`
-
-error[E0277]: `(dyn Future<Output = u32> + 'static)` cannot be sent between threads safely
-  --> tests/integration/ui/compile_fail/attr_into_future.rs:67:17
-   |
-67 |     assert_send(&sut().value(21).into_future());
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Future<Output = u32> + 'static)` cannot be sent between threads safely
-   |
-   = help: the trait `Send` is not implemented for `(dyn Future<Output = u32> + 'static)`
-   = note: required for `Unique<(dyn Future<Output = u32> + 'static)>` to implement `Send`
-note: required because it appears within the type `Box<(dyn Future<Output = u32> + 'static)>`
-  --> $RUST/alloc/src/boxed.rs
-   |
-   | pub struct Box<
-   |            ^^^
-note: required because it appears within the type `Pin<Box<(dyn Future<Output = u32> + 'static)>>`
-  --> $RUST/core/src/pin.rs
-   |
-   | pub struct Pin<Ptr> {
-   |            ^^^
-   = note: required for the cast from `&Pin<Box<(dyn Future<Output = u32> + 'static)>>` to `&dyn Send`

--- a/bon/tests/integration/ui/compile_fail/attr_into_future.stderr
+++ b/bon/tests/integration/ui/compile_fail/attr_into_future.stderr
@@ -1,43 +1,83 @@
 error: `#[builder(derive(IntoFuture(...)))` can only be used with async functions; using it with a synchronous function is likely a mistake
- --> tests/integration/ui/compile_fail/attr_into_future.rs:2:1
+ --> tests/integration/ui/compile_fail/attr_into_future.rs:5:1
   |
-2 | #[bon::builder]
+5 | #[bon::builder]
   | ^^^^^^^^^^^^^^^
   |
   = note: this error originates in the attribute macro `bon::builder` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `#[builder(derive(IntoFuture(...)))` is not supported for unsafe functions because `IntoFuture::into_future()` method is a safe method
-  --> tests/integration/ui/compile_fail/attr_into_future.rs:11:7
+  --> tests/integration/ui/compile_fail/attr_into_future.rs:14:7
    |
-11 | async unsafe fn unsafe_async_function() -> u32 {
+14 | async unsafe fn unsafe_async_function() -> u32 {
    |       ^^^^^^
 
 error: `#[builder(derive(IntoFuture(...)))` is incompatible with `#[builder(finish_fn)]` members because `IntoFuture::into_future()` method accepts zero parameters
-  --> tests/integration/ui/compile_fail/attr_into_future.rs:19:15
+  --> tests/integration/ui/compile_fail/attr_into_future.rs:21:35
    |
-19 |     #[builder(finish_fn)] value: u32
-   |               ^^^^^^^^^
+21 | async fn with_finish_fn(#[builder(finish_fn)] value: u32) -> u32 {
+   |                                   ^^^^^^^^^
 
 error: expected an attribute of form `IntoFuture(Box, ...)`
-  --> tests/integration/ui/compile_fail/attr_into_future.rs:26:18
+  --> tests/integration/ui/compile_fail/attr_into_future.rs:27:18
    |
-26 | #[builder(derive(IntoFuture))]
+27 | #[builder(derive(IntoFuture))]
    |                  ^^^^^^^^^^
 
 error: expected `Box` as the first argument, only boxed futures are supported
-  --> tests/integration/ui/compile_fail/attr_into_future.rs:33:29
+  --> tests/integration/ui/compile_fail/attr_into_future.rs:34:29
    |
-33 | #[builder(derive(IntoFuture(Arc)))]
+34 | #[builder(derive(IntoFuture(Arc)))]
    |                             ^^^
 
 error: expected `?Send` as the second argument
-  --> tests/integration/ui/compile_fail/attr_into_future.rs:40:34
+  --> tests/integration/ui/compile_fail/attr_into_future.rs:41:34
    |
-40 | #[builder(derive(IntoFuture(Box, Send)))]
+41 | #[builder(derive(IntoFuture(Box, Send)))]
    |                                  ^^^^
 
 error: `#[builder(derive(IntoFuture(...)))` can only be used with async functions; using it with a synchronous function is likely a mistake
-  --> tests/integration/ui/compile_fail/attr_into_future.rs:50:8
+  --> tests/integration/ui/compile_fail/attr_into_future.rs:49:8
    |
-50 | struct AsyncConfig {
+49 | struct AsyncConfig {
    |        ^^^^^^^^^^^
+
+error[E0277]: `dyn Future<Output = u32>` cannot be sent between threads safely
+  --> tests/integration/ui/compile_fail/attr_into_future.rs:66:17
+   |
+66 |     assert_send(&Sut.sut().value(21).into_future());
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `dyn Future<Output = u32>` cannot be sent between threads safely
+   |
+   = help: the trait `Send` is not implemented for `dyn Future<Output = u32>`
+   = note: required for `Unique<dyn Future<Output = u32>>` to implement `Send`
+note: required because it appears within the type `Box<dyn Future<Output = u32>>`
+  --> $RUST/alloc/src/boxed.rs
+   |
+   | pub struct Box<
+   |            ^^^
+note: required because it appears within the type `Pin<Box<dyn Future<Output = u32>>>`
+  --> $RUST/core/src/pin.rs
+   |
+   | pub struct Pin<Ptr> {
+   |            ^^^
+   = note: required for the cast from `&Pin<Box<dyn Future<Output = u32>>>` to `&dyn Send`
+
+error[E0277]: `(dyn Future<Output = u32> + 'static)` cannot be sent between threads safely
+  --> tests/integration/ui/compile_fail/attr_into_future.rs:73:17
+   |
+73 |     assert_send(&sut().value(21).into_future());
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Future<Output = u32> + 'static)` cannot be sent between threads safely
+   |
+   = help: the trait `Send` is not implemented for `(dyn Future<Output = u32> + 'static)`
+   = note: required for `Unique<(dyn Future<Output = u32> + 'static)>` to implement `Send`
+note: required because it appears within the type `Box<(dyn Future<Output = u32> + 'static)>`
+  --> $RUST/alloc/src/boxed.rs
+   |
+   | pub struct Box<
+   |            ^^^
+note: required because it appears within the type `Pin<Box<(dyn Future<Output = u32> + 'static)>>`
+  --> $RUST/core/src/pin.rs
+   |
+   | pub struct Pin<Ptr> {
+   |            ^^^
+   = note: required for the cast from `&Pin<Box<(dyn Future<Output = u32> + 'static)>>` to `&dyn Send`

--- a/bon/tests/integration/ui/compile_fail/attr_into_future.stderr
+++ b/bon/tests/integration/ui/compile_fail/attr_into_future.stderr
@@ -1,0 +1,45 @@
+error: `#[builder(derive(IntoFuture(...)))` can only be used with async functions
+                       because `IntoFuture::into_future()` method is an asynchronous method
+ --> tests/integration/ui/compile_fail/attr_into_future.rs:2:1
+  |
+2 | #[bon::builder]
+  | ^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `bon::builder` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: `#[builder(derive(IntoFuture(...)))` is not supported for unsafe functions because `IntoFuture::into_future()` method is a safe method
+  --> tests/integration/ui/compile_fail/attr_into_future.rs:11:7
+   |
+11 | async unsafe fn unsafe_async_function() -> u32 {
+   |       ^^^^^^
+
+error: `#[builder(derive(IntoFuture(...)))` is incompatible with `#[builder(finish_fn)]` members because `IntoFuture::into_future()` method accepts zero parameters
+  --> tests/integration/ui/compile_fail/attr_into_future.rs:19:15
+   |
+19 |     #[builder(finish_fn)] value: u32
+   |               ^^^^^^^^^
+
+error: expected attribute arguments in parentheses: `IntoFuture(...)`
+  --> tests/integration/ui/compile_fail/attr_into_future.rs:26:18
+   |
+26 | #[builder(derive(IntoFuture))]
+   |                  ^^^^^^^^^^
+
+error: expected `Box` as the first argument, only boxed futures are supported
+  --> tests/integration/ui/compile_fail/attr_into_future.rs:33:29
+   |
+33 | #[builder(derive(IntoFuture(Arc)))]
+   |                             ^^^
+
+error: expected `?Send` as the second argument
+  --> tests/integration/ui/compile_fail/attr_into_future.rs:40:34
+   |
+40 | #[builder(derive(IntoFuture(Box, Send)))]
+   |                                  ^^^^
+
+error: `#[builder(derive(IntoFuture(...)))` can only be used with async functions
+                       because `IntoFuture::into_future()` method is an asynchronous method
+  --> tests/integration/ui/compile_fail/attr_into_future.rs:50:8
+   |
+50 | struct AsyncConfig {
+   |        ^^^^^^^^^^^

--- a/bon/tests/integration/ui/compile_fail/attr_into_future.stderr
+++ b/bon/tests/integration/ui/compile_fail/attr_into_future.stderr
@@ -1,4 +1,4 @@
-error: `#[builder(derive(IntoFuture(...)))` can only be used with async functions because `IntoFuture::into_future()` method is an asynchronous method
+error: `#[builder(derive(IntoFuture(...)))` can only be used with async functions; using it with a synchronous function is likely a mistake
  --> tests/integration/ui/compile_fail/attr_into_future.rs:2:1
   |
 2 | #[bon::builder]
@@ -36,7 +36,7 @@ error: expected `?Send` as the second argument
 40 | #[builder(derive(IntoFuture(Box, Send)))]
    |                                  ^^^^
 
-error: `#[builder(derive(IntoFuture(...)))` can only be used with async functions because `IntoFuture::into_future()` method is an asynchronous method
+error: `#[builder(derive(IntoFuture(...)))` can only be used with async functions; using it with a synchronous function is likely a mistake
   --> tests/integration/ui/compile_fail/attr_into_future.rs:50:8
    |
 50 | struct AsyncConfig {

--- a/bon/tests/integration/ui/compile_fail/std_or_alloc/attr_into_future.rs
+++ b/bon/tests/integration/ui/compile_fail/std_or_alloc/attr_into_future.rs
@@ -1,0 +1,27 @@
+use bon::{bon, builder};
+use core::future::IntoFuture;
+
+fn _non_send() {
+    struct Sut;
+
+    fn assert_send(_: &dyn Send) {}
+
+    #[bon]
+    impl Sut {
+        #[builder(derive(IntoFuture(Box, ?Send)))]
+        async fn sut(&self, value: u32) -> u32 {
+            value * 2
+        }
+    }
+
+    assert_send(&Sut.sut().value(21).into_future());
+
+    #[builder(derive(IntoFuture(Box, ?Send)))]
+    async fn sut(value: u32) -> u32 {
+        value * 2
+    }
+
+    assert_send(&sut().value(21).into_future());
+}
+
+fn main() {}

--- a/bon/tests/integration/ui/compile_fail/std_or_alloc/attr_into_future.stderr
+++ b/bon/tests/integration/ui/compile_fail/std_or_alloc/attr_into_future.stderr
@@ -1,0 +1,39 @@
+error[E0277]: `dyn Future<Output = u32>` cannot be sent between threads safely
+  --> tests/integration/ui/compile_fail/std_or_alloc/attr_into_future.rs:17:17
+   |
+17 |     assert_send(&Sut.sut().value(21).into_future());
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `dyn Future<Output = u32>` cannot be sent between threads safely
+   |
+   = help: the trait `Send` is not implemented for `dyn Future<Output = u32>`
+   = note: required for `Unique<dyn Future<Output = u32>>` to implement `Send`
+note: required because it appears within the type `Box<dyn Future<Output = u32>>`
+  --> $RUST/alloc/src/boxed.rs
+   |
+   | pub struct Box<
+   |            ^^^
+note: required because it appears within the type `Pin<Box<dyn Future<Output = u32>>>`
+  --> $RUST/core/src/pin.rs
+   |
+   | pub struct Pin<Ptr> {
+   |            ^^^
+   = note: required for the cast from `&Pin<Box<dyn Future<Output = u32>>>` to `&dyn Send`
+
+error[E0277]: `(dyn Future<Output = u32> + 'static)` cannot be sent between threads safely
+  --> tests/integration/ui/compile_fail/std_or_alloc/attr_into_future.rs:24:17
+   |
+24 |     assert_send(&sut().value(21).into_future());
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Future<Output = u32> + 'static)` cannot be sent between threads safely
+   |
+   = help: the trait `Send` is not implemented for `(dyn Future<Output = u32> + 'static)`
+   = note: required for `Unique<(dyn Future<Output = u32> + 'static)>` to implement `Send`
+note: required because it appears within the type `Box<(dyn Future<Output = u32> + 'static)>`
+  --> $RUST/alloc/src/boxed.rs
+   |
+   | pub struct Box<
+   |            ^^^
+note: required because it appears within the type `Pin<Box<(dyn Future<Output = u32> + 'static)>>`
+  --> $RUST/core/src/pin.rs
+   |
+   | pub struct Pin<Ptr> {
+   |            ^^^
+   = note: required for the cast from `&Pin<Box<(dyn Future<Output = u32> + 'static)>>` to `&dyn Send`

--- a/bon/tests/integration/ui/mod.rs
+++ b/bon/tests/integration/ui/mod.rs
@@ -3,4 +3,9 @@
 fn ui() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/integration/ui/compile_fail/*.rs");
+
+    if cfg!(any(feature = "std", feature = "alloc")) {
+        let t = trybuild::TestCases::new();
+        t.compile_fail("tests/integration/ui/compile_fail/std_or_alloc/*.rs");
+    }
 }

--- a/website/doctests/Cargo.toml
+++ b/website/doctests/Cargo.toml
@@ -16,6 +16,7 @@ anyhow                = "1.0"
 bon                   = { path = "../../bon", features = ["experimental-overwritable", "implied-bounds"] }
 buildstructor         = "0.6"
 macro_rules_attribute = "0.2"
+tokio-test            = "0.4.4"
 typed-builder         = "0.21"
 
 [build-dependencies]

--- a/website/doctests/Cargo.toml
+++ b/website/doctests/Cargo.toml
@@ -16,7 +16,7 @@ anyhow                = "1.0"
 bon                   = { path = "../../bon", features = ["experimental-overwritable", "implied-bounds"] }
 buildstructor         = "0.6"
 macro_rules_attribute = "0.2"
-tokio-test            = "0.4.4"
+tokio                 = { version = "1.47", features = ["macros", "rt-multi-thread"] }
 typed-builder         = "0.21"
 
 [build-dependencies]

--- a/website/src/reference/builder/top-level/derive.md
+++ b/website/src/reference/builder/top-level/derive.md
@@ -280,13 +280,14 @@ Implements [`IntoFuture`](https://doc.rust-lang.org/std/future/trait.IntoFuture.
 use bon::builder;
 
 #[builder(derive(IntoFuture(Box)))]
-async fn fetch_string(url: &str, body: Option<Vec<u8>>) -> std::io::Result<String> {
+async fn fetch_string(url: &str, body: Option<Vec<u8>>) -> String {
     // …
-    Ok("Server response".to_owned())
+    "Server response".to_owned()
 }
 
-tokio_test::block_on(async {
+#[tokio::main]
+async fn main() {
     let response = fetch_string().url("https://example.org").await;
-    assert_eq!(response.ok().as_deref(), Some("Server response"));
-})
+    assert_eq!(response, "Server response");
+}
 ```

--- a/website/src/reference/builder/top-level/derive.md
+++ b/website/src/reference/builder/top-level/derive.md
@@ -292,6 +292,8 @@ async fn main() {
 }
 ```
 
+Take into account that `IntoFuture` trait became stable in Rust `1.64`, which is important if you care about your MSRV.
+
 ### Lifetimes caveat
 
 There is a caveat that `dyn Trait` objects can only have a single `+ 'lifetime` bound which is the Rust language's fundamental limitation. So the generated `IntoFuture` implementation squashes all lifetimes into a single `'builder` lifetime. This means it's not strictly equivalent the default `finish_fn` in terms of lifetimes. This should generally not be a problem unless the output type of the function's `Future` contains more than one lifetime.

--- a/website/src/reference/builder/top-level/derive.md
+++ b/website/src/reference/builder/top-level/derive.md
@@ -291,3 +291,7 @@ async fn main() {
     assert_eq!(response, "Server response");
 }
 ```
+
+### Lifetimes caveat
+
+There is a caveat that `dyn Trait` objects can only have a single `+ 'lifetime` bound which is the Rust language's fundamental limitation. So the generated `IntoFuture` implementation squashes all lifetimes into a single `'builder` lifetime. This means it's not strictly equivalent the default `finish_fn` in terms of lifetimes. This should generally not be a problem unless the output type of the function's `Future` contains more than one lifetime.


### PR DESCRIPTION
Addresses #314.

This allows for a derivation of the `IntoFuture` trait which enables a pattern by which a builder holding all required properties and ready to be finalised, can be `await`ed on to produce the final result asynchronously.