### PR TITLE
Add Copyright header to the MIT License

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,3 +1,7 @@
+The MIT License (MIT)
+
+Copyright (c) 2024 Elastio Software Inc
+
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated
 documentation files (the "Software"), to deal in the


### PR DESCRIPTION
The MIT license has a standard header for the copyright notice. Apache doesn't seem to have one. Anyway, I think this should be enough