### PR TITLE
Revert refactoring PR 320 to make code compatible with darling 0.20

### DIFF
--- a/bon-macros/src/builder/builder_gen/input_fn/validation.rs
+++ b/bon-macros/src/builder/builder_gen/input_fn/validation.rs
@@ -30,12 +30,14 @@ impl super::FnInputCtx<'_> {
             }
         }
 
-        if self.config.const_.is_present() && self.fn_item.orig.sig.constness.is_none() {
-            bail!(
-                &self.config.const_.span(),
-                "#[builder(const)] requires the underlying function to be \
-                marked as `const fn`"
-            );
+        if let Some(const_) = &self.config.const_ {
+            if self.fn_item.orig.sig.constness.is_none() {
+                bail!(
+                    &const_,
+                    "#[builder(const)] requires the underlying function to be \
+                    marked as `const fn`"
+                );
+            }
         }
 
         Ok(())

--- a/bon-macros/src/builder/builder_gen/member/config/mod.rs
+++ b/bon-macros/src/builder/builder_gen/member/config/mod.rs
@@ -209,7 +209,7 @@ impl MemberConfig {
     }
 
     pub(crate) fn validate(&self, top_config: &TopLevelConfig, origin: MemberOrigin) -> Result {
-        if top_config.const_.is_present() {
+        if top_config.const_.is_some() {
             self.require_const_compat()?;
         }
 

--- a/bon-macros/src/builder/builder_gen/models.rs
+++ b/bon-macros/src/builder/builder_gen/models.rs
@@ -181,7 +181,7 @@ pub(super) struct BuilderGenCtxParams<'a> {
     pub(super) members: Vec<Member>,
 
     pub(super) allow_attrs: Vec<syn::Attribute>,
-    pub(super) const_: darling::util::Flag,
+    pub(super) const_: Option<syn::Token![const]>,
     pub(super) on: Vec<OnConfig>,
 
     /// This is the visibility of the original item that the builder is generated for.
@@ -356,10 +356,6 @@ impl BuilderGenCtx {
                 receiver,
             }
         });
-
-        let const_ = const_
-            .is_present()
-            .then(|| syn::Token![const](const_.span()));
 
         Ok(Self {
             bon,

--- a/bon/tests/integration/builder/attr_const.rs
+++ b/bon/tests/integration/builder/attr_const.rs
@@ -9,8 +9,7 @@ mod msrv_1_61 {
         #[test]
         const fn test_struct() {
             #[derive(Builder)]
-            // Make sure `const` is parsed if it's not the first attribute
-            #[builder(builder_type(vis = ""), const)]
+            #[builder(const)]
             struct Sut {
                 #[builder(start_fn)]
                 x1: u32,


### PR DESCRIPTION
This reverts commit 1006408567e2644f0f32f074ab119e09ae92771c.

As discussed in https://github.com/elastio/bon/issues/330#issuecomment-3197859360

Will keep this refactoring for a later time, to ease the packaging of `bon` for Debian for now