### PR TITLE
Set lowerbound of `rustversion` of to v1.0.19

### DIFF
--- a/bon-macros/Cargo.toml
+++ b/bon-macros/Cargo.toml
@@ -58,7 +58,7 @@ quote = "1"
 syn = { version = "2.0.56", features = ["full", "visit-mut", "visit"] }
 
 prettyplease = "0.2"
-rustversion  = "1.0"
+rustversion  = "1.0.18"
 
 [features]
 default = []


### PR DESCRIPTION
I got the following error in Iceberg-Rust:

```
   --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bon-macros-3.7.0/src/builder/builder_gen/getters.rs:227:46
    |
227 |                 let module = if rustversion::cfg!(since(1.64.0)) {
    |                                              ^^^ could not find `cfg` in `rustversion`

```

Which depends on Avro-rs, and Avro-rs depends on Bon.

It looks like `rustversion::cfg!` has been added in 1.0.19:

- https://crates.io/crates/rustversion/1.0.19
- https://crates.io/crates/rustversion/1.0.18