### PR TITLE
Preserve `fn` and `{}` for `start_fn` so that rustdoc generates correct links

### DIFF
--- a/bon-macros/src/builder/builder_gen/input_fn/mod.rs
+++ b/bon-macros/src/builder/builder_gen/input_fn/mod.rs
@@ -97,6 +97,9 @@ impl<'a> FnInputCtx<'a> {
                     .collect(),
                 params.fn_item.norm.sig.generics.where_clause.clone(),
             )),
+
+            orig_fn_token: Some(params.fn_item.orig.sig.fn_token),
+            orig_brace_tokens: Some(params.fn_item.orig.block.brace_token),
         };
 
         let self_ty_prefix = params.impl_ctx.as_deref().and_then(|impl_ctx| {

--- a/bon-macros/src/builder/builder_gen/input_fn/mod.rs
+++ b/bon-macros/src/builder/builder_gen/input_fn/mod.rs
@@ -12,6 +12,7 @@ use crate::util::prelude::*;
 use std::borrow::Cow;
 use std::rc::Rc;
 use syn::punctuated::Punctuated;
+use syn::spanned::Spanned;
 use syn::visit_mut::VisitMut;
 
 pub(crate) struct FnInputCtx<'a> {
@@ -97,9 +98,11 @@ impl<'a> FnInputCtx<'a> {
                     .collect(),
                 params.fn_item.norm.sig.generics.where_clause.clone(),
             )),
-
-            orig_fn_token: Some(params.fn_item.orig.sig.fn_token),
-            orig_brace_tokens: Some(params.fn_item.orig.block.brace_token),
+            // We don't use params.fn_item.orig.span() here because that span
+            // only contains the annotations before the function and the
+            // function name. Block contains function name + implementation
+            // which is what rustdoc normally links to.
+            span: Some(params.fn_item.orig.block.span()),
         };
 
         let self_ty_prefix = params.impl_ctx.as_deref().and_then(|impl_ctx| {

--- a/bon-macros/src/builder/builder_gen/input_struct.rs
+++ b/bon-macros/src/builder/builder_gen/input_struct.rs
@@ -187,6 +187,8 @@ impl StructInputCtx {
             vis: start_fn_vis.map(SpannedKey::into_value),
             docs: start_fn_docs,
             generics: None,
+            orig_brace_tokens: None,
+            orig_fn_token: None,
         };
 
         let assoc_method_ctx = Some(AssocMethodCtxParams {

--- a/bon-macros/src/builder/builder_gen/input_struct.rs
+++ b/bon-macros/src/builder/builder_gen/input_struct.rs
@@ -187,8 +187,7 @@ impl StructInputCtx {
             vis: start_fn_vis.map(SpannedKey::into_value),
             docs: start_fn_docs,
             generics: None,
-            orig_brace_tokens: None,
-            orig_fn_token: None,
+            span: None,
         };
 
         let assoc_method_ctx = Some(AssocMethodCtxParams {

--- a/bon-macros/src/builder/builder_gen/models.rs
+++ b/bon-macros/src/builder/builder_gen/models.rs
@@ -86,12 +86,8 @@ pub(super) struct StartFn {
     /// Overrides the default generics
     pub(super) generics: Option<Generics>,
 
-    /// Preserve the original fn token span.
-    /// This determines the generated fn's span start
-    pub(super) fn_token: syn::token::Fn,
-    /// Preserve the original brace token.
-    /// This determines the generated fn's span end
-    pub(super) brace_tokens: syn::token::Brace,
+    /// Preserve a span the documentation for `start_fn` should link to.
+    pub(super) span: Span,
 }
 
 pub(super) struct StartFnParams {
@@ -104,12 +100,9 @@ pub(super) struct StartFnParams {
 
     /// Overrides the default generics
     pub(super) generics: Option<Generics>,
-    /// Preserve original fn token for its span if possible. Defaults to
-    /// macro callsite if not supplied.
-    pub(super) orig_fn_token: Option<syn::token::Fn>,
-    /// Preserve original brace tokens `{}` for their spans if possible.
+    /// Preserve a span the documentation for `start_fn` should link to.
     /// Defaults to macro callsite if not supplied.
-    pub(super) orig_brace_tokens: Option<syn::token::Brace>,
+    pub(super) span: Option<Span>,
 }
 
 pub(super) struct BuilderType {
@@ -322,8 +315,7 @@ impl BuilderGenCtx {
             vis: start_fn.vis.unwrap_or_else(|| builder_type.vis.clone()),
             docs: start_fn.docs,
             generics: start_fn.generics,
-            fn_token: start_fn.orig_fn_token.unwrap_or_default(),
-            brace_tokens: start_fn.orig_brace_tokens.unwrap_or_default(),
+            span: start_fn.span.unwrap_or_else(Span::call_site),
         };
 
         let finish_fn = FinishFn {

--- a/bon-macros/src/builder/builder_gen/models.rs
+++ b/bon-macros/src/builder/builder_gen/models.rs
@@ -88,10 +88,10 @@ pub(super) struct StartFn {
 
     /// Preserve the original fn token span.
     /// This determines the generated fn's span start
-    pub(super) orig_fn_token: syn::token::Fn,
+    pub(super) fn_token: syn::token::Fn,
     /// Preserve the original brace token.
     /// This determines the generated fn's span end
-    pub(super) orig_brace_tokens: syn::token::Brace,
+    pub(super) brace_tokens: syn::token::Brace,
 }
 
 pub(super) struct StartFnParams {
@@ -322,8 +322,8 @@ impl BuilderGenCtx {
             vis: start_fn.vis.unwrap_or_else(|| builder_type.vis.clone()),
             docs: start_fn.docs,
             generics: start_fn.generics,
-            orig_fn_token: start_fn.orig_fn_token.unwrap_or_default(),
-            orig_brace_tokens: start_fn.orig_brace_tokens.unwrap_or_default(),
+            fn_token: start_fn.orig_fn_token.unwrap_or_default(),
+            brace_tokens: start_fn.orig_brace_tokens.unwrap_or_default(),
         };
 
         let finish_fn = FinishFn {

--- a/bon-macros/src/builder/builder_gen/models.rs
+++ b/bon-macros/src/builder/builder_gen/models.rs
@@ -85,6 +85,13 @@ pub(super) struct StartFn {
 
     /// Overrides the default generics
     pub(super) generics: Option<Generics>,
+
+    /// Preserve the original fn token span.
+    /// This determines the generated fn's span start
+    pub(super) orig_fn_token: syn::token::Fn,
+    /// Preserve the original brace token.
+    /// This determines the generated fn's span end
+    pub(super) orig_brace_tokens: syn::token::Brace,
 }
 
 pub(super) struct StartFnParams {
@@ -97,6 +104,12 @@ pub(super) struct StartFnParams {
 
     /// Overrides the default generics
     pub(super) generics: Option<Generics>,
+    /// Preserve original fn token for its span if possible. Defaults to
+    /// macro callsite if not supplied.
+    pub(super) orig_fn_token: Option<syn::token::Fn>,
+    /// Preserve original brace tokens `{}` for their spans if possible.
+    /// Defaults to macro callsite if not supplied.
+    pub(super) orig_brace_tokens: Option<syn::token::Brace>,
 }
 
 pub(super) struct BuilderType {
@@ -309,6 +322,8 @@ impl BuilderGenCtx {
             vis: start_fn.vis.unwrap_or_else(|| builder_type.vis.clone()),
             docs: start_fn.docs,
             generics: start_fn.generics,
+            orig_fn_token: start_fn.orig_fn_token.unwrap_or_default(),
+            orig_brace_tokens: start_fn.orig_brace_tokens.unwrap_or_default(),
         };
 
         let finish_fn = FinishFn {

--- a/bon-macros/src/builder/builder_gen/start_fn.rs
+++ b/bon-macros/src/builder/builder_gen/start_fn.rs
@@ -96,28 +96,27 @@ impl super::BuilderGenCtx {
             };
 
         let const_ = &self.const_;
-        let fn_kw = self.start_fn.orig_fn_token;
+        let fn_kw = self.start_fn.fn_token;
 
         // construct function body separately so that we can reuse the original
         // function's braces and span. Reusing the span makes rustdoc link
         // our generated function to the original function rather than the
         // macro invocation site.
-        let body_contents: Vec<syn::Stmt> = syn::parse_quote! {
-            #ide_hints
-            #( #start_fn_vars )*
-            #( #custom_fields_vars )*
+        let body_span = self.start_fn.brace_tokens.span;
+        let body_block = quote_spanned! {body_span=>
+            {
+                #ide_hints
+                #( #start_fn_vars )*
+                #( #custom_fields_vars )*
 
-            #builder_ident {
-                __unsafe_private_phantom: ::core::marker::PhantomData,
-                #( #custom_fields_idents, )*
-                #receiver_field_init
-                #( #start_fn_args_fields_idents, )*
-                __unsafe_private_named: #named_members_field_init,
+                #builder_ident {
+                    __unsafe_private_phantom: ::core::marker::PhantomData,
+                    #( #custom_fields_idents, )*
+                    #receiver_field_init
+                    #( #start_fn_args_fields_idents, )*
+                    __unsafe_private_named: #named_members_field_init,
+                }
             }
-        };
-        let body_block = syn::Block {
-            brace_token: self.start_fn.orig_brace_tokens,
-            stmts: body_contents,
         };
 
         syn::parse_quote! {

--- a/bon-macros/src/builder/builder_gen/start_fn.rs
+++ b/bon-macros/src/builder/builder_gen/start_fn.rs
@@ -103,19 +103,11 @@ impl super::BuilderGenCtx {
         // `elidable_lifetime_names` (See
         // https://github.com/elastio/bon/pull/341#discussion_r2398893516 for
         // an explanation).
-        #[rustversion::before(1.87)]
-        fn get_needless_lifetime_lint_annotation() -> TokenStream {
-            quote! {
-                #[allow(clippy::needless_lifetimes)]
-            }
-        }
-        #[rustversion::since(1.87)]
-        fn get_needless_lifetime_lint_annotation() -> TokenStream {
-            quote! {
-                #[allow(clippy::elidable_lifetime_names)]
-            }
-        }
-        let needless_lifetime_lint = get_needless_lifetime_lint_annotation();
+        let needless_lifetime_lint = if rustversion::cfg!(before(1.87)) {
+            format_ident!("needless_lifetimes")
+        } else {
+            format_ident!("elidable_lifetime_names")
+        };
 
         // Construct using a span which links to our original implementation.
         // This ensures rustdoc doesn't just link every method to the macro
@@ -131,8 +123,8 @@ impl super::BuilderGenCtx {
                 // Let's keep it as non-const for now to avoid restricting ourselfves to only
                 // const operations.
                 clippy::missing_const_for_fn,
+                clippy::#needless_lifetime_lint
             )]
-            #needless_lifetime_lint
             #vis #const_ fn #start_fn_ident< #(#generics_decl),* >(
                 #receiver
                 #(#start_fn_params,)*

--- a/bon-macros/src/builder/builder_gen/start_fn.rs
+++ b/bon-macros/src/builder/builder_gen/start_fn.rs
@@ -116,6 +116,7 @@ impl super::BuilderGenCtx {
                 // https://github.com/elastio/bon/pull/341#discussion_r2398893516
                 // for an explanation.
                 clippy::elidable_lifetime_names,
+                clippy::needless_lifetimes,
             )]
             #vis #const_ fn #start_fn_ident< #(#generics_decl),* >(
                 #receiver

--- a/bon-macros/src/builder/builder_gen/start_fn.rs
+++ b/bon-macros/src/builder/builder_gen/start_fn.rs
@@ -111,6 +111,11 @@ impl super::BuilderGenCtx {
                 // Let's keep it as non-const for now to avoid restricting ourselfves to only
                 // const operations.
                 clippy::missing_const_for_fn,
+                // Hide generics with elidable lifetimes. Clippy may suggest
+                // eliding lifetimes even when it is wrong. See
+                // https://github.com/elastio/bon/pull/341#discussion_r2398893516
+                // for an explanation.
+                clippy::elidable_lifetime_names,
             )]
             #vis #const_ fn #start_fn_ident< #(#generics_decl),* >(
                 #receiver

--- a/bon/src/lib.rs
+++ b/bon/src/lib.rs
@@ -14,7 +14,7 @@
 // Rexport all macros from the proc-macro crate.
 pub use bon_macros::{bon, builder, map, set, Builder};
 
-/// Small utility declarative macros for creating colletions with [`Into`] conversions.
+/// Small utility declarative macros for creating collections with [`Into`] conversions.
 mod collections;
 
 #[doc(hidden)]

--- a/bon/tests/integration/builder/attr_bon.rs
+++ b/bon/tests/integration/builder/attr_bon.rs
@@ -102,6 +102,7 @@ fn receiver_variations() {
         }
 
         #[builder]
+        #[allow(dead_code)]
         fn mut_self_as_pin_mut_self(mut self: Pin<&mut Self>) {
             #[allow(clippy::self_assignment, unused_assignments)]
             {

--- a/bon/tests/integration/builder/attr_const.rs
+++ b/bon/tests/integration/builder/attr_const.rs
@@ -205,6 +205,7 @@ mod msrv_1_61 {
         #[test]
         const fn test_function() {
             #[builder(const)]
+            #[allow(unreachable_pub)]
             pub const fn sut(#[builder(getter)] _x: u32) {}
 
             sut().x(1).call();
@@ -217,6 +218,7 @@ mod msrv_1_61 {
             #[bon]
             impl Sut {
                 #[builder(const)]
+                #[allow(unreachable_pub)]
                 pub const fn sut(#[builder(getter)] _x: u32) {}
             }
 

--- a/bon/tests/integration/builder/attr_top_level_start_fn.rs
+++ b/bon/tests/integration/builder/attr_top_level_start_fn.rs
@@ -52,6 +52,7 @@ fn test_method() {
 fn test_function() {
     {
         #[builder(start_fn(name = sut_builder))]
+        #[allow(dead_code)]
         fn sut(arg1: bool, arg2: u32) -> impl fmt::Debug {
             (arg1, arg2)
         }
@@ -61,6 +62,7 @@ fn test_function() {
 
     {
         #[builder(start_fn = sut_builder)]
+        #[allow(dead_code)]
         fn sut(arg1: u32) -> u32 {
             arg1
         }
@@ -70,6 +72,7 @@ fn test_function() {
 
     {
         #[builder(start_fn(name = sut_builder, vis = ""))]
+        #[allow(dead_code)]
         fn sut(arg1: u32) -> u32 {
             arg1
         }


### PR DESCRIPTION
## Preserve `fn` and `{}` during `start_fn` construction
Closes #57.

This PR changes the generation of `start_fn` such that it reuses the `fn` keyword and `{` `}` tokens from the original definition.

This fix works because rustdoc only considers the spans of the first and last tokens when determining the span of a function. In our case, the start token is `pub`, `const` or `fn`. The ending token is `}`. The original code already preserves `pub` and `const` so I have added code for preserving `fn` and `{}`.

The original implementation relies on `quote!` for generating `{`, `}` and `fn` which default to `Span::call_site()` which is why rustdoc linked to the macro callsite instead of the original function.

## Seeing the changes
Some methods in the bon sandbox such as https://github.com/elastio/bon/blob/c0e4356d174faf108101fbb9141effbd06980ced/bon-sandbox/src/docs_comparison/methods.rs#L10-L26 should now generate a correct source link that links to the original function. Can be tested using `cargo doc --package bon-sandbox --open`.

## Possible future improvements
Since rustdoc only cares about the start and end tokens, it is theoretically possible to modify builder method generation such that it also reuses the spans of the original struct member/parameter definitions (not implemented in this PR). This would be more complicated because you would have to assign spans from one type of token to another type of token which I haven't tested yet. I might make an issue for that later after digging through more of the codebase and thinking a bit more.