### PR TITLE
fix: `clippy::wrong_self_convention` warning for fields with `is_` prefix etc.

### DIFF
--- a/bon-macros/src/builder/builder_gen/setters/mod.rs
+++ b/bon-macros/src/builder/builder_gen/setters/mod.rs
@@ -467,6 +467,10 @@ impl<'a> SettersCtx<'a> {
                 // your design of this setter already went wrong.
                 clippy::impl_trait_in_params,
                 clippy::missing_const_for_fn,
+                // When having a field which has one of the prefixes listed by
+                // `clippy::wrong_self_convention` you will end up getting said lint
+                // warning in your `bon::Builder` because we take self by value.
+                clippy::wrong_self_convention,
             )]
             #[inline(always)]
             #(#fn_modifiers)* fn #name(#maybe_mut #self_, #( #pats: #types ),*) -> #return_type


### PR DESCRIPTION
When having a field which has one of the prefixes listed by `clippy::wrong_self_convention` you will end up getting said lint warning in your `bon::Builder` macro:

```rust
#[derive(Builder)]
struct Unique {
    is_unique: bool,
}
```

```
warning: methods called `is_*` usually take `self` by mutable reference or `self` by reference or no `self`
 --> src/main.rs:7:10
  |
7 | #[derive(Builder)]
  |          ^^^^^^^
  |
  = help: consider choosing a less ambiguous name
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#wrong_self_convention
  = note: `#[warn(clippy::wrong_self_convention)]` on by default
  = note: this warning originates in the derive macro `Builder` (in Nightly builds, run with -Z macro-backtrace for more info)
```

This PR proposes to add `#[allow(clippy::wrong_self_convention)]` to all generated setters to avoid this lint warning entirely. 