### PR TITLE
Fix rust-analyzer "Go to Definition" inside `#[builder]` functions

### DIFF
--- a/bon-macros/src/builder/builder_gen/start_fn.rs
+++ b/bon-macros/src/builder/builder_gen/start_fn.rs
@@ -109,10 +109,7 @@ impl super::BuilderGenCtx {
             format_ident!("elidable_lifetime_names")
         };
 
-        // Construct using a span which links to our original implementation.
-        // This ensures rustdoc doesn't just link every method to the macro
-        // callsite.
-        syn::parse_quote_spanned! {self.start_fn.span=>
+        let mut start_fn: syn::ItemFn = syn::parse_quote! {
             #(#docs)*
             #[inline(always)]
             #[allow(
@@ -143,6 +140,13 @@ impl super::BuilderGenCtx {
                     __unsafe_private_named: #named_members_field_init,
                 }
             }
-        }
+        };
+
+        let span = self.start_fn.span;
+
+        start_fn.sig.fn_token = syn::Token![fn](span);
+        start_fn.block.brace_token = syn::token::Brace(span);
+
+        start_fn
     }
 }


### PR DESCRIPTION
Rust-analyzer's "Go to Definition" function is currently broken when used inside a function annotated with `#[builder]` because of [the way it prioritizes spans](https://github.com/rust-lang/rust-analyzer/issues/18438).

Prior to this change, using "Go to Definition" on any token within the function body led the analyzer wildly astray. After the fix, it correctly jumps to the item definition.

As far as I can tell, this change doesn't introduce any regressions or changes in generated documentation.