### PR TITLE
Build from

### DIFF
--- a/bon-macros/Cargo.toml
+++ b/bon-macros/Cargo.toml
@@ -71,6 +71,8 @@ std   = []
 # See the docs on this feature in the `bon`'s crate `Cargo.toml`
 experimental-overwritable = []
 
+experimental-build-from = []
+
 # See the docs on this feature in the `bon`'s crate `Cargo.toml`
 experimental-generics-setters = []
 

--- a/bon-macros/src/builder/builder_gen/build_from.rs
+++ b/bon-macros/src/builder/builder_gen/build_from.rs
@@ -2,7 +2,7 @@ use crate::builder::builder_gen::{BuilderGenCtx, member::Member};
 use crate::util::prelude::*;
 use proc_macro2::{Ident, Span};
 use quote::quote;
-use syn::{Type, spanned::Spanned};
+use syn::{Type, ext::IdentExt, spanned::Spanned};
 
 pub(super) fn emit(ctx: &BuilderGenCtx, target_ty: &Type) -> Result<TokenStream> {
     let mut tokens = TokenStream::new();
@@ -17,23 +17,25 @@ pub(super) fn emit(ctx: &BuilderGenCtx, target_ty: &Type) -> Result<TokenStream>
 
     let base_name = ctx.finish_fn.ident.clone();
 
-    if ctx.build_from {
+    if ctx.build_from.is_some() {
         tokens.extend(emit_build_from_method(
             false,
             &base_name,
             target_ty,
             &ctx.members,
             &ctor_args,
-        ));
+            ctx.build_from.as_ref(),
+        )?);
     }
 
-    if ctx.build_from_clone {
+    if ctx.build_from_clone.is_some() {
         tokens.extend(emit_build_from_method(
             true,
             &base_name,
             target_ty,
             &ctx.members,
             &ctor_args,
+            ctx.build_from_clone.as_ref(),
         )?);
     }
 
@@ -46,6 +48,7 @@ fn emit_build_from_method(
     target_ty: &Type,
     members: &[Member],
     ctor_args: &[TokenStream],
+    config: Option<&crate::parsing::ItemSigConfig>,
 ) -> Result<TokenStream> {
     let doc = if clone {
         "Fills unset builder fields from a reference to the target type and builds it."
@@ -53,11 +56,15 @@ fn emit_build_from_method(
         "Fills unset builder fields from an owned value of the target type and builds it."
     };
 
-    let method_name = if clone {
-        format_ident!("{}_from_clone", base_name)
-    } else {
-        format_ident!("{}_from", base_name)
-    };
+    let method_name: Ident = config
+        .and_then(|cfg| cfg.name.as_ref().map(|spanned_key| spanned_key.unraw()))
+        .unwrap_or_else(|| {
+            if clone {
+                format_ident!("{}_from_clone", base_name)
+            } else {
+                format_ident!("{}_from", base_name)
+            }
+        });
 
     let arg_type = if clone {
         quote!(&#target_ty)
@@ -136,8 +143,6 @@ fn field_vars_from_members(members: &[Member], clone: bool) -> Vec<TokenStream> 
 }
 
 pub(crate) fn extract_ctor_ident_path(ty: &Type, span: Span) -> Result<TokenStream> {
-    use quote::quote_spanned;
-
     let path = ty.as_path_no_qself().ok_or_else(|| {
         err!(
             &span,

--- a/bon-macros/src/builder/builder_gen/build_from.rs
+++ b/bon-macros/src/builder/builder_gen/build_from.rs
@@ -145,12 +145,14 @@ pub(crate) fn extract_ctor_ident_path(ty: &Type, span: Span) -> Result<TokenStre
         )
     })?;
 
-    let ident = path
+    let mut ident = path
         .segments
         .last()
         .ok_or_else(|| err!(&span, "expected a named type, but found an empty path"))?
         .ident
         .clone();
 
-    Ok(quote_spanned! { span => #ident })
+    ident.set_span(span);
+
+    Ok(quote! { #ident })
 }

--- a/bon-macros/src/builder/builder_gen/build_from.rs
+++ b/bon-macros/src/builder/builder_gen/build_from.rs
@@ -1,9 +1,10 @@
 use crate::builder::builder_gen::{BuilderGenCtx, member::Member};
 use crate::util::prelude::*;
+use proc_macro2::Span;
 use quote::quote;
-use syn::Type;
+use syn::{Type, spanned::Spanned};
 
-pub(super) fn emit(ctx: &BuilderGenCtx, target_ty: &Type) -> TokenStream {
+pub(super) fn emit(ctx: &BuilderGenCtx, target_ty: &Type) -> Result<TokenStream> {
     let mut tokens = TokenStream::new();
 
     let field_vars: Vec<_> = ctx
@@ -61,10 +62,10 @@ pub(super) fn emit(ctx: &BuilderGenCtx, target_ty: &Type) -> TokenStream {
             target_ty,
             &field_vars,
             &ctor_args,
-        ));
+        )?);
     }
 
-    tokens
+    Ok(tokens)
 }
 
 fn emit_build_from_method(
@@ -72,7 +73,7 @@ fn emit_build_from_method(
     target_ty: &Type,
     field_vars: &[TokenStream],
     ctor_args: &[TokenStream],
-) -> TokenStream {
+) -> Result<TokenStream> {
     let doc = if clone {
         "Fills unset builder fields from an owned value of the target type and builds it."
     } else {
@@ -97,15 +98,9 @@ fn emit_build_from_method(
         quote!(from)
     };
 
-    // Convert `target_ty` to a path segment with no generics
-    let ctor_path = if let Type::Path(type_path) = target_ty {
-        let ident = &type_path.path.segments.last().unwrap().ident;
-        quote!(#ident)
-    } else {
-        quote!(#target_ty)
-    };
+    let ctor_path = extract_ctor_ident_path(target_ty, target_ty.span())?;
 
-    quote! {
+    Ok(quote! {
         #[inline(always)]
         #[doc = #doc]
         pub fn #method_name(self, #arg_pat: #arg_type) -> #target_ty {
@@ -114,5 +109,25 @@ fn emit_build_from_method(
                 #( #ctor_args, )*
             }
         }
-    }
+    })
+}
+
+pub(crate) fn extract_ctor_ident_path(ty: &Type, span: Span) -> Result<TokenStream> {
+    use quote::quote_spanned;
+
+    let path = ty.as_path_no_qself().ok_or_else(|| {
+        err!(
+            &span,
+            "expected a concrete type path (like `MyStruct`) for constructor"
+        )
+    })?;
+
+    let ident = path
+        .segments
+        .last()
+        .ok_or_else(|| err!(&span, "expected a named type, but found an empty path"))?
+        .ident
+        .clone();
+
+    Ok(quote_spanned! { span => #ident })
 }

--- a/bon-macros/src/builder/builder_gen/build_from.rs
+++ b/bon-macros/src/builder/builder_gen/build_from.rs
@@ -14,9 +14,7 @@ pub(super) fn emit(ctx: &BuilderGenCtx, target_ty: &Type) -> Result<TokenStream>
             quote! { #ident }
         })
         .collect();
-
     let base_name = ctx.finish_fn.ident.clone();
-
     if ctx.build_from.is_some() {
         tokens.extend(emit_build_from_method(
             false,
@@ -27,7 +25,6 @@ pub(super) fn emit(ctx: &BuilderGenCtx, target_ty: &Type) -> Result<TokenStream>
             ctx.build_from.as_ref(),
         )?);
     }
-
     if ctx.build_from_clone.is_some() {
         tokens.extend(emit_build_from_method(
             true,
@@ -38,7 +35,6 @@ pub(super) fn emit(ctx: &BuilderGenCtx, target_ty: &Type) -> Result<TokenStream>
             ctx.build_from_clone.as_ref(),
         )?);
     }
-
     Ok(tokens)
 }
 
@@ -55,7 +51,6 @@ fn emit_build_from_method(
     } else {
         "Fills unset builder fields from an owned value of the target type and builds it."
     };
-
     let method_name: Ident = config
         .and_then(|cfg| cfg.name.as_ref().map(|spanned_key| spanned_key.unraw()))
         .unwrap_or_else(|| {
@@ -65,22 +60,18 @@ fn emit_build_from_method(
                 format_ident!("{}_from", base_name)
             }
         });
-
     let arg_type = if clone {
         quote!(&#target_ty)
     } else {
         quote!(#target_ty)
     };
-
     let arg_pat = if clone {
         quote!(mut from)
     } else {
         quote!(from)
     };
-
     let ctor_path = extract_ctor_ident_path(target_ty, target_ty.span())?;
     let field_vars = field_vars_from_members(members, clone);
-
     Ok(quote! {
         #[inline(always)]
         #[doc = #doc]
@@ -100,7 +91,6 @@ fn field_vars_from_members(members: &[Member], clone: bool) -> Vec<TokenStream> 
             let ident = member.orig_ident();
             let ty = member.norm_ty();
             let default_expr = quote! { ::core::default::Default::default() };
-
             match member {
                 Member::Field(_) | Member::StartFn(_) => quote! {
                     let #ident: #ty = self.#ident;
@@ -149,15 +139,10 @@ pub(crate) fn extract_ctor_ident_path(ty: &Type, span: Span) -> Result<TokenStre
             "expected a concrete type path (like `MyStruct`) for constructor"
         )
     })?;
-
-    let mut ident = path
-        .segments
-        .last()
-        .ok_or_else(|| err!(&span, "expected a named type, but found an empty path"))?
-        .ident
-        .clone();
-
-    ident.set_span(span);
-
-    Ok(quote! { #ident })
+    let mut clean_path = path.clone();
+    if let Some(last_segment) = clean_path.segments.last_mut() {
+        last_segment.arguments = syn::PathArguments::None;
+        last_segment.ident.set_span(span);
+    }
+    Ok(quote! { #clean_path })
 }

--- a/bon-macros/src/builder/builder_gen/build_from.rs
+++ b/bon-macros/src/builder/builder_gen/build_from.rs
@@ -1,0 +1,119 @@
+use crate::builder::builder_gen::{BuilderGenCtx, member::Member};
+use crate::util::prelude::*;
+use quote::quote;
+use syn::Type;
+
+pub(super) fn emit(ctx: &BuilderGenCtx, target_ty: &Type) -> TokenStream {
+    let mut tokens = TokenStream::new();
+
+    let field_vars: Vec<_> = ctx
+        .members
+        .iter()
+        .map(|member| {
+            let ident = member.orig_ident();
+            let ty = member.norm_ty();
+            let default_expr = quote! { ::core::default::Default::default() };
+
+            match member {
+                Member::Field(_) | Member::StartFn(_) => quote! {
+                    let #ident: #ty = self.#ident;
+                },
+                Member::Named(member) => {
+                    let index = &member.index;
+                    quote! {
+                        let #ident: #ty = match self.__unsafe_private_named.#index {
+                            Some(value) => value,
+                            None => from.#ident.clone(),
+                        };
+                    }
+                }
+                Member::FinishFn(_) => quote! {
+                    let #ident: #ty = from.#ident.clone();
+                },
+                Member::Skip(_) => quote! {
+                    let #ident: #ty = #default_expr;
+                },
+            }
+        })
+        .collect();
+
+    let ctor_args: Vec<_> = ctx
+        .members
+        .iter()
+        .map(|m| {
+            let ident = m.orig_ident();
+            quote! { #ident }
+        })
+        .collect();
+
+    if ctx.build_from {
+        tokens.extend(emit_build_from_method(
+            false,
+            target_ty,
+            &field_vars,
+            &ctor_args,
+        ));
+    }
+
+    if ctx.build_from_clone {
+        tokens.extend(emit_build_from_method(
+            true,
+            target_ty,
+            &field_vars,
+            &ctor_args,
+        ));
+    }
+
+    tokens
+}
+
+fn emit_build_from_method(
+    clone: bool,
+    target_ty: &Type,
+    field_vars: &[TokenStream],
+    ctor_args: &[TokenStream],
+) -> TokenStream {
+    let doc = if clone {
+        "Fills unset builder fields from an owned value of the target type and builds it."
+    } else {
+        "Fills unset builder fields from a reference to the target type and builds it."
+    };
+
+    let method_name = if clone {
+        quote!(build_from_clone)
+    } else {
+        quote!(build_from)
+    };
+
+    let arg_type = if clone {
+        quote!(#target_ty)
+    } else {
+        quote!(&#target_ty)
+    };
+
+    let arg_pat = if clone {
+        quote!(mut from)
+    } else {
+        quote!(from)
+    };
+
+    // Fix: Convert `target_ty` to a path segment with no generics
+    let ctor_path = match target_ty {
+        Type::Path(type_path) => {
+            let ident = &type_path.path.segments.last().unwrap().ident;
+            quote!(#ident)
+        }
+        _ => quote!(#target_ty), // fallback for non-path types
+    };
+
+    quote! {
+        #[inline(always)]
+        #[doc = #doc]
+        pub fn #method_name(self, #arg_pat: #arg_type) -> #target_ty {
+            #( #field_vars )*
+            #ctor_path {
+                #( #ctor_args, )*
+            }
+        }
+    }
+}

--- a/bon-macros/src/builder/builder_gen/build_from.rs
+++ b/bon-macros/src/builder/builder_gen/build_from.rs
@@ -98,12 +98,11 @@ fn emit_build_from_method(
     };
 
     // Convert `target_ty` to a path segment with no generics
-    let ctor_path = match target_ty {
-        Type::Path(type_path) => {
-            let ident = &type_path.path.segments.last().unwrap().ident;
-            quote!(#ident)
-        }
-        _ => quote!(#target_ty),
+    let ctor_path = if let Type::Path(type_path) = target_ty {
+        let ident = &type_path.path.segments.last().unwrap().ident;
+        quote!(#ident)
+    } else {
+        quote!(#target_ty)
     };
 
     quote! {

--- a/bon-macros/src/builder/builder_gen/build_from.rs
+++ b/bon-macros/src/builder/builder_gen/build_from.rs
@@ -1,14 +1,93 @@
 use crate::builder::builder_gen::{BuilderGenCtx, member::Member};
 use crate::util::prelude::*;
-use proc_macro2::Span;
+use proc_macro2::{Ident, Span};
 use quote::quote;
 use syn::{Type, spanned::Spanned};
 
 pub(super) fn emit(ctx: &BuilderGenCtx, target_ty: &Type) -> Result<TokenStream> {
     let mut tokens = TokenStream::new();
-
-    let field_vars: Vec<_> = ctx
+    let ctor_args: Vec<_> = ctx
         .members
+        .iter()
+        .map(|m| {
+            let ident = m.orig_ident();
+            quote! { #ident }
+        })
+        .collect();
+
+    let base_name = ctx.finish_fn.ident.clone();
+
+    if ctx.build_from {
+        tokens.extend(emit_build_from_method(
+            false,
+            &base_name,
+            target_ty,
+            &ctx.members,
+            &ctor_args,
+        ));
+    }
+
+    if ctx.build_from_clone {
+        tokens.extend(emit_build_from_method(
+            true,
+            &base_name,
+            target_ty,
+            &ctx.members,
+            &ctor_args,
+        )?);
+    }
+
+    Ok(tokens)
+}
+
+fn emit_build_from_method(
+    clone: bool,
+    base_name: &Ident,
+    target_ty: &Type,
+    members: &[Member],
+    ctor_args: &[TokenStream],
+) -> Result<TokenStream> {
+    let doc = if clone {
+        "Fills unset builder fields from an owned value of the target type and builds it."
+    } else {
+        "Fills unset builder fields from a reference to the target type and builds it."
+    };
+
+    let method_name = if clone {
+        format_ident!("{}_from_clone", base_name)
+    } else {
+        format_ident!("{}_from", base_name)
+    };
+
+    let arg_type = if clone {
+        quote!(&#target_ty)
+    } else {
+        quote!(#target_ty)
+    };
+
+    let arg_pat = if clone {
+        quote!(mut from)
+    } else {
+        quote!(from)
+    };
+
+    let ctor_path = extract_ctor_ident_path(target_ty, target_ty.span())?;
+    let field_vars = field_vars_from_members(members, clone);
+
+    Ok(quote! {
+        #[inline(always)]
+        #[doc = #doc]
+        pub fn #method_name(self, #arg_pat: #arg_type) -> #target_ty {
+            #( #field_vars )*
+            #ctor_path {
+                #( #ctor_args, )*
+            }
+        }
+    })
+}
+
+fn field_vars_from_members(members: &[Member], clone: bool) -> Vec<TokenStream> {
+    members
         .iter()
         .map(|member| {
             let ident = member.orig_ident();
@@ -21,95 +100,39 @@ pub(super) fn emit(ctx: &BuilderGenCtx, target_ty: &Type) -> Result<TokenStream>
                 },
                 Member::Named(member) => {
                     let index = &member.index;
-                    quote! {
-                        let #ident: #ty = match self.__unsafe_private_named.#index {
-                            Some(value) => value,
-                            None => from.#ident.clone(),
-                        };
+                    if clone {
+                        quote! {
+                            let #ident: #ty = match self.__unsafe_private_named.#index {
+                                Some(value) => value,
+                                None => from.#ident.clone(),
+                            };
+                        }
+                    } else {
+                        quote! {
+                            let #ident: #ty = match self.__unsafe_private_named.#index {
+                                Some(value) => value,
+                                None => from.#ident,
+                            };
+                        }
                     }
                 }
-                Member::FinishFn(_) => quote! {
-                    let #ident: #ty = from.#ident.clone();
-                },
+                Member::FinishFn(_) => {
+                    if clone {
+                        quote! {
+                            let #ident: #ty = from.#ident.clone();
+                        }
+                    } else {
+                        quote! {
+                            let #ident: #ty = from.#ident;
+                        }
+                    }
+                }
                 Member::Skip(_) => quote! {
                     let #ident: #ty = #default_expr;
                 },
             }
         })
-        .collect();
-
-    let ctor_args: Vec<_> = ctx
-        .members
-        .iter()
-        .map(|m| {
-            let ident = m.orig_ident();
-            quote! { #ident }
-        })
-        .collect();
-
-    if ctx.build_from {
-        tokens.extend(emit_build_from_method(
-            false,
-            target_ty,
-            &field_vars,
-            &ctor_args,
-        ));
-    }
-
-    if ctx.build_from_clone {
-        tokens.extend(emit_build_from_method(
-            true,
-            target_ty,
-            &field_vars,
-            &ctor_args,
-        )?);
-    }
-
-    Ok(tokens)
-}
-
-fn emit_build_from_method(
-    clone: bool,
-    target_ty: &Type,
-    field_vars: &[TokenStream],
-    ctor_args: &[TokenStream],
-) -> Result<TokenStream> {
-    let doc = if clone {
-        "Fills unset builder fields from an owned value of the target type and builds it."
-    } else {
-        "Fills unset builder fields from a reference to the target type and builds it."
-    };
-
-    let method_name = if clone {
-        quote!(build_from_clone)
-    } else {
-        quote!(build_from)
-    };
-
-    let arg_type = if clone {
-        quote!(#target_ty)
-    } else {
-        quote!(&#target_ty)
-    };
-
-    let arg_pat = if clone {
-        quote!(mut from)
-    } else {
-        quote!(from)
-    };
-
-    let ctor_path = extract_ctor_ident_path(target_ty, target_ty.span())?;
-
-    Ok(quote! {
-        #[inline(always)]
-        #[doc = #doc]
-        pub fn #method_name(self, #arg_pat: #arg_type) -> #target_ty {
-            #( #field_vars )*
-            #ctor_path {
-                #( #ctor_args, )*
-            }
-        }
-    })
+        .collect()
 }
 
 pub(crate) fn extract_ctor_ident_path(ty: &Type, span: Span) -> Result<TokenStream> {

--- a/bon-macros/src/builder/builder_gen/build_from.rs
+++ b/bon-macros/src/builder/builder_gen/build_from.rs
@@ -48,9 +48,9 @@ fn emit_build_from_method(
     ctor_args: &[TokenStream],
 ) -> Result<TokenStream> {
     let doc = if clone {
-        "Fills unset builder fields from an owned value of the target type and builds it."
-    } else {
         "Fills unset builder fields from a reference to the target type and builds it."
+    } else {
+        "Fills unset builder fields from an owned value of the target type and builds it."
     };
 
     let method_name = if clone {

--- a/bon-macros/src/builder/builder_gen/build_from.rs
+++ b/bon-macros/src/builder/builder_gen/build_from.rs
@@ -97,13 +97,13 @@ fn emit_build_from_method(
         quote!(from)
     };
 
-    // Fix: Convert `target_ty` to a path segment with no generics
+    // Convert `target_ty` to a path segment with no generics
     let ctor_path = match target_ty {
         Type::Path(type_path) => {
             let ident = &type_path.path.segments.last().unwrap().ident;
             quote!(#ident)
         }
-        _ => quote!(#target_ty), // fallback for non-path types
+        _ => quote!(#target_ty),
     };
 
     quote! {

--- a/bon-macros/src/builder/builder_gen/input_fn/mod.rs
+++ b/bon-macros/src/builder/builder_gen/input_fn/mod.rs
@@ -422,7 +422,9 @@ impl<'a> FnInputCtx<'a> {
             state_mod: self.config.state_mod,
             start_fn: self.start_fn,
             finish_fn,
+            #[cfg(feature = "experimental-build-from")]
             build_from: self.config.build_from,
+            #[cfg(feature = "experimental-build-from")]
             build_from_clone: self.config.build_from_clone,
         })
     }

--- a/bon-macros/src/builder/builder_gen/input_fn/mod.rs
+++ b/bon-macros/src/builder/builder_gen/input_fn/mod.rs
@@ -422,6 +422,8 @@ impl<'a> FnInputCtx<'a> {
             state_mod: self.config.state_mod,
             start_fn: self.start_fn,
             finish_fn,
+            build_from: self.config.build_from,
+            build_from_clone: self.config.build_from_clone,
         })
     }
 }

--- a/bon-macros/src/builder/builder_gen/input_struct.rs
+++ b/bon-macros/src/builder/builder_gen/input_struct.rs
@@ -244,7 +244,9 @@ impl StructInputCtx {
             state_mod: self.config.state_mod,
             start_fn,
             finish_fn,
+            #[cfg(feature = "experimental-build-from")]
             build_from: self.config.build_from,
+            #[cfg(feature = "experimental-build-from")]
             build_from_clone: self.config.build_from_clone,
         })
     }

--- a/bon-macros/src/builder/builder_gen/input_struct.rs
+++ b/bon-macros/src/builder/builder_gen/input_struct.rs
@@ -244,6 +244,8 @@ impl StructInputCtx {
             state_mod: self.config.state_mod,
             start_fn,
             finish_fn,
+            build_from: self.config.build_from,
+            build_from_clone: self.config.build_from_clone,
         })
     }
 }

--- a/bon-macros/src/builder/builder_gen/member/config/mod.rs
+++ b/bon-macros/src/builder/builder_gen/member/config/mod.rs
@@ -65,6 +65,9 @@ pub(crate) struct MemberConfig {
     /// this option to see if it's worth it.
     pub(crate) overwritable: darling::util::Flag,
 
+    /// Allows the use of `build_from` and `build_from_clone` methods.
+    pub(crate) build_from: darling::util::Flag,
+
     /// Disables the special handling for a member of type `Option<T>`. The
     /// member no longer has the default of `None`. It also becomes a required
     /// member unless a separate `#[builder(default = ...)]` attribute is
@@ -102,6 +105,7 @@ enum ParamName {
     Into,
     Name,
     Overwritable,
+    BuildFrom,
     Required,
     Setters,
     Skip,
@@ -119,6 +123,7 @@ impl fmt::Display for ParamName {
             Self::Into => "into",
             Self::Name => "name",
             Self::Overwritable => "overwritable",
+            Self::BuildFrom => "build_from",
             Self::Required => "required",
             Self::Setters => "setters",
             Self::Skip => "skip",
@@ -184,6 +189,7 @@ impl MemberConfig {
             into,
             name,
             overwritable,
+            build_from,
             required,
             setters,
             skip,
@@ -199,6 +205,7 @@ impl MemberConfig {
             (into.is_present(), ParamName::Into),
             (name.is_some(), ParamName::Name),
             (overwritable.is_present(), ParamName::Overwritable),
+            (build_from.is_present(), ParamName::BuildFrom),
             (required.is_present(), ParamName::Required),
             (setters.is_some(), ParamName::Setters),
             (skip.is_some(), ParamName::Skip),
@@ -229,6 +236,22 @@ impl MemberConfig {
                  a comment under the issue for us to understand how it's used \
                  in practice",
             );
+        }
+
+        if !cfg!(feature = "experimental-build-from") && self.build_from.is_present() {
+            bail!(
+                &self.build_from.span(),
+                "🔬 `build_from` attribute is experimental and requires \
+                 \"experimental-build-from\" cargo feature to be enabled.",
+            );
+        }
+
+        if let Some(getter) = &self.getter {
+            self.validate_mutually_exclusive(
+                ParamName::Getter,
+                getter.key.span(),
+                &[ParamName::Overwritable],
+            )?;
         }
 
         if self.start_fn.is_present() {

--- a/bon-macros/src/builder/builder_gen/member/config/mod.rs
+++ b/bon-macros/src/builder/builder_gen/member/config/mod.rs
@@ -246,14 +246,6 @@ impl MemberConfig {
             );
         }
 
-        if let Some(getter) = &self.getter {
-            self.validate_mutually_exclusive(
-                ParamName::Getter,
-                getter.key.span(),
-                &[ParamName::Overwritable],
-            )?;
-        }
-
         if self.start_fn.is_present() {
             self.validate_mutually_allowed(
                 ParamName::StartFn,

--- a/bon-macros/src/builder/builder_gen/mod.rs
+++ b/bon-macros/src/builder/builder_gen/mod.rs
@@ -1,3 +1,4 @@
+mod build_from;
 mod builder_decl;
 mod builder_derives;
 mod finish_fn;
@@ -144,6 +145,11 @@ impl BuilderGenCtx {
 
         let allows = allow_warnings_on_member_types();
 
+        let build_froms = match &self.finish_fn.output {
+            syn::ReturnType::Type(_, ty) => build_from::emit(self, ty),
+            syn::ReturnType::Default => quote! {},
+        };
+
         Ok(quote! {
             #allows
             // Ignore dead code warnings because some setter/getter methods may
@@ -158,6 +164,7 @@ impl BuilderGenCtx {
             #where_clause
             {
                 #finish_fn
+                #build_froms
                 #(#accessor_methods)*
                 #generic_setter_methods
             }

--- a/bon-macros/src/builder/builder_gen/mod.rs
+++ b/bon-macros/src/builder/builder_gen/mod.rs
@@ -150,12 +150,15 @@ impl BuilderGenCtx {
         let build_froms = {
             #[cfg(feature = "experimental-build-from")]
             {
-                match &self.finish_fn.output {
-                    syn::ReturnType::Type(_, ty) => build_from::emit(self, ty)?,
-                    syn::ReturnType::Default => quote! {},
+                if self.build_from.is_some() || self.build_from_clone.is_some() {
+                    match &self.finish_fn.output {
+                        syn::ReturnType::Type(_, ty) => build_from::emit(self, ty)?,
+                        syn::ReturnType::Default => quote! {},
+                    }
+                } else {
+                    quote! {}
                 }
             }
-
             #[cfg(not(feature = "experimental-build-from"))]
             {
                 quote! {}

--- a/bon-macros/src/builder/builder_gen/mod.rs
+++ b/bon-macros/src/builder/builder_gen/mod.rs
@@ -1,4 +1,6 @@
+#[cfg(feature = "experimental-build-from")]
 mod build_from;
+
 mod builder_decl;
 mod builder_derives;
 mod finish_fn;
@@ -145,9 +147,19 @@ impl BuilderGenCtx {
 
         let allows = allow_warnings_on_member_types();
 
-        let build_froms = match &self.finish_fn.output {
-            syn::ReturnType::Type(_, ty) => build_from::emit(self, ty)?,
-            syn::ReturnType::Default => quote! {},
+        let build_froms = {
+            #[cfg(feature = "experimental-build-from")]
+            {
+                match &self.finish_fn.output {
+                    syn::ReturnType::Type(_, ty) => build_from::emit(self, ty)?,
+                    syn::ReturnType::Default => quote! {},
+                }
+            }
+
+            #[cfg(not(feature = "experimental-build-from"))]
+            {
+                quote! {}
+            }
         };
 
         Ok(quote! {

--- a/bon-macros/src/builder/builder_gen/mod.rs
+++ b/bon-macros/src/builder/builder_gen/mod.rs
@@ -146,7 +146,7 @@ impl BuilderGenCtx {
         let allows = allow_warnings_on_member_types();
 
         let build_froms = match &self.finish_fn.output {
-            syn::ReturnType::Type(_, ty) => build_from::emit(self, ty),
+            syn::ReturnType::Type(_, ty) => build_from::emit(self, ty)?,
             syn::ReturnType::Default => quote! {},
         };
 

--- a/bon-macros/src/builder/builder_gen/models.rs
+++ b/bon-macros/src/builder/builder_gen/models.rs
@@ -5,6 +5,12 @@ use crate::parsing::{BonCratePath, ItemSigConfig, SpannedKey};
 use crate::util::prelude::*;
 use std::borrow::Cow;
 
+#[cfg(feature = "experimental-build-from")]
+use darling::util::Override;
+
+#[cfg(feature = "experimental-build-from")]
+use crate::parsing::ItemSigConfigParsing;
+
 pub(super) trait FinishFnBody {
     /// Generate the `finish` function body from the ready-made variables.
     /// The generated function body may assume that there are variables
@@ -217,9 +223,9 @@ pub(super) struct BuilderGenCtxParams<'a> {
     pub(super) start_fn: StartFnParams,
     pub(super) finish_fn: FinishFnParams,
     #[cfg(feature = "experimental-build-from")]
-    pub(super) build_from: Option<ItemSigConfig>,
+    pub(super) build_from: Option<Override<syn::Meta>>,
     #[cfg(feature = "experimental-build-from")]
-    pub(super) build_from_clone: Option<ItemSigConfig>,
+    pub(super) build_from_clone: Option<Override<syn::Meta>>,
 }
 
 impl BuilderGenCtx {
@@ -239,12 +245,27 @@ impl BuilderGenCtx {
             state_mod,
             start_fn,
             finish_fn,
-            ..
+            #[cfg(feature = "experimental-build-from")]
+            build_from,
+            #[cfg(feature = "experimental-build-from")]
+            build_from_clone,
         } = params;
+
         #[cfg(feature = "experimental-build-from")]
-        let build_from = params.build_from;
+        let build_from = build_from
+            .map(|wrapped_override| match wrapped_override {
+                Override::Inherit => Ok(ItemSigConfig::default()),
+                Override::Explicit(meta) => ItemSigConfigParsing::new(&meta, None).parse(),
+            })
+            .transpose()?;
+
         #[cfg(feature = "experimental-build-from")]
-        let build_from_clone = params.build_from_clone;
+        let build_from_clone = build_from_clone
+            .map(|wrapped_override| match wrapped_override {
+                Override::Inherit => Ok(ItemSigConfig::default()),
+                Override::Explicit(meta) => ItemSigConfigParsing::new(&meta, None).parse(),
+            })
+            .transpose()?;
 
         let builder_type = BuilderType {
             ident: builder_type.ident,

--- a/bon-macros/src/builder/builder_gen/models.rs
+++ b/bon-macros/src/builder/builder_gen/models.rs
@@ -183,6 +183,8 @@ pub(crate) struct BuilderGenCtx {
     pub(super) state_mod: StateMod,
     pub(super) start_fn: StartFn,
     pub(super) finish_fn: FinishFn,
+    pub(super) build_from: bool,
+    pub(super) build_from_clone: bool,
 }
 
 pub(super) struct BuilderGenCtxParams<'a> {
@@ -212,6 +214,8 @@ pub(super) struct BuilderGenCtxParams<'a> {
     pub(super) state_mod: ItemSigConfig,
     pub(super) start_fn: StartFnParams,
     pub(super) finish_fn: FinishFnParams,
+    pub(super) build_from: bool,
+    pub(super) build_from_clone: bool,
 }
 
 impl BuilderGenCtx {
@@ -231,6 +235,8 @@ impl BuilderGenCtx {
             state_mod,
             start_fn,
             finish_fn,
+            build_from,
+            build_from_clone,
         } = params;
 
         let builder_type = BuilderType {
@@ -385,6 +391,8 @@ impl BuilderGenCtx {
             state_mod,
             start_fn,
             finish_fn,
+            build_from,
+            build_from_clone,
         })
     }
 }

--- a/bon-macros/src/builder/builder_gen/models.rs
+++ b/bon-macros/src/builder/builder_gen/models.rs
@@ -183,7 +183,9 @@ pub(crate) struct BuilderGenCtx {
     pub(super) state_mod: StateMod,
     pub(super) start_fn: StartFn,
     pub(super) finish_fn: FinishFn,
+    #[cfg(feature = "experimental-build-from")]
     pub(super) build_from: bool,
+    #[cfg(feature = "experimental-build-from")]
     pub(super) build_from_clone: bool,
 }
 
@@ -214,7 +216,9 @@ pub(super) struct BuilderGenCtxParams<'a> {
     pub(super) state_mod: ItemSigConfig,
     pub(super) start_fn: StartFnParams,
     pub(super) finish_fn: FinishFnParams,
+    #[cfg(feature = "experimental-build-from")]
     pub(super) build_from: bool,
+    #[cfg(feature = "experimental-build-from")]
     pub(super) build_from_clone: bool,
 }
 
@@ -235,9 +239,12 @@ impl BuilderGenCtx {
             state_mod,
             start_fn,
             finish_fn,
-            build_from,
-            build_from_clone,
+            ..
         } = params;
+        #[cfg(feature = "experimental-build-from")]
+        let build_from = params.build_from;
+        #[cfg(feature = "experimental-build-from")]
+        let build_from_clone = params.build_from_clone;
 
         let builder_type = BuilderType {
             ident: builder_type.ident,
@@ -391,7 +398,9 @@ impl BuilderGenCtx {
             state_mod,
             start_fn,
             finish_fn,
+            #[cfg(feature = "experimental-build-from")]
             build_from,
+            #[cfg(feature = "experimental-build-from")]
             build_from_clone,
         })
     }

--- a/bon-macros/src/builder/builder_gen/models.rs
+++ b/bon-macros/src/builder/builder_gen/models.rs
@@ -184,9 +184,9 @@ pub(crate) struct BuilderGenCtx {
     pub(super) start_fn: StartFn,
     pub(super) finish_fn: FinishFn,
     #[cfg(feature = "experimental-build-from")]
-    pub(super) build_from: bool,
+    pub(super) build_from: Option<ItemSigConfig>,
     #[cfg(feature = "experimental-build-from")]
-    pub(super) build_from_clone: bool,
+    pub(super) build_from_clone: Option<ItemSigConfig>,
 }
 
 pub(super) struct BuilderGenCtxParams<'a> {
@@ -217,9 +217,9 @@ pub(super) struct BuilderGenCtxParams<'a> {
     pub(super) start_fn: StartFnParams,
     pub(super) finish_fn: FinishFnParams,
     #[cfg(feature = "experimental-build-from")]
-    pub(super) build_from: bool,
+    pub(super) build_from: Option<ItemSigConfig>,
     #[cfg(feature = "experimental-build-from")]
-    pub(super) build_from_clone: bool,
+    pub(super) build_from_clone: Option<ItemSigConfig>,
 }
 
 impl BuilderGenCtx {

--- a/bon-macros/src/builder/builder_gen/top_level_config/mod.rs
+++ b/bon-macros/src/builder/builder_gen/top_level_config/mod.rs
@@ -12,6 +12,9 @@ use syn::ItemFn;
 use syn::parse::Parser;
 use syn::punctuated::Punctuated;
 
+#[cfg(feature = "experimental-build-from")]
+use darling::util::Override;
+
 fn parse_finish_fn(meta: &syn::Meta) -> Result<ItemSigConfig> {
     ItemSigConfigParsing::new(meta, Some("builder struct's impl block")).parse()
 }
@@ -26,28 +29,6 @@ fn parse_state_mod(meta: &syn::Meta) -> Result<ItemSigConfig> {
 
 fn parse_start_fn(meta: &syn::Meta) -> Result<ItemSigConfig> {
     ItemSigConfigParsing::new(meta, None).parse()
-}
-
-#[cfg(feature = "experimental-build-from")]
-fn parse_build_from(meta: &syn::Meta) -> Result<Option<ItemSigConfig>> {
-    let config = ItemSigConfigParsing {
-        meta,
-        reject_self_mentions: Some("builder struct's impl block"),
-    }
-    .parse()?;
-
-    Ok(Some(config))
-}
-
-#[cfg(feature = "experimental-build-from")]
-fn parse_build_from_clone(meta: &syn::Meta) -> Result<Option<ItemSigConfig>> {
-    let config = ItemSigConfigParsing {
-        meta,
-        reject_self_mentions: Some("builder struct's impl block"),
-    }
-    .parse()?;
-
-    Ok(Some(config))
 }
 
 #[derive(Debug, FromMeta)]
@@ -89,12 +70,12 @@ pub(crate) struct TopLevelConfig {
     pub(crate) generics: Option<SpannedKey<GenericsConfig>>,
 
     #[cfg(feature = "experimental-build-from")]
-    #[darling(default, with = parse_build_from)]
-    pub(crate) build_from: Option<ItemSigConfig>,
+    #[darling(default)]
+    pub(crate) build_from: Option<Override<syn::Meta>>,
 
     #[cfg(feature = "experimental-build-from")]
-    #[darling(default, with = parse_build_from_clone)]
-    pub(crate) build_from_clone: Option<ItemSigConfig>,
+    #[darling(default)]
+    pub(crate) build_from_clone: Option<Override<syn::Meta>>,
 }
 
 impl TopLevelConfig {

--- a/bon-macros/src/builder/builder_gen/top_level_config/mod.rs
+++ b/bon-macros/src/builder/builder_gen/top_level_config/mod.rs
@@ -28,6 +28,24 @@ fn parse_start_fn(meta: &syn::Meta) -> Result<ItemSigConfig> {
     ItemSigConfigParsing::new(meta, None).parse()
 }
 
+#[cfg(feature = "experimental-build-from")]
+fn parse_build_from(meta: &syn::Meta) -> Result<ItemSigConfig> {
+    ItemSigConfigParsing {
+        meta,
+        reject_self_mentions: Some("builder struct's impl block"),
+    }
+    .parse()
+}
+
+#[cfg(feature = "experimental-build-from")]
+fn parse_build_from_clone(meta: &syn::Meta) -> Result<ItemSigConfig> {
+    ItemSigConfigParsing {
+        meta,
+        reject_self_mentions: Some("builder struct's impl block"),
+    }
+    .parse()
+}
+
 #[derive(Debug, FromMeta)]
 pub(crate) struct TopLevelConfig {
     /// Specifies whether the generated functions should be `const`.
@@ -67,12 +85,12 @@ pub(crate) struct TopLevelConfig {
     pub(crate) generics: Option<SpannedKey<GenericsConfig>>,
 
     #[cfg(feature = "experimental-build-from")]
-    #[darling(default)]
-    pub(crate) build_from: bool,
+    #[darling(default, with = parse_build_from)]
+    pub(crate) build_from: ItemSigConfig,
 
     #[cfg(feature = "experimental-build-from")]
-    #[darling(default)]
-    pub(crate) build_from_clone: bool,
+    #[darling(default, with = parse_build_from_clone)]
+    pub(crate) build_from_clone: ItemSigConfig,
 }
 
 impl TopLevelConfig {

--- a/bon-macros/src/builder/builder_gen/top_level_config/mod.rs
+++ b/bon-macros/src/builder/builder_gen/top_level_config/mod.rs
@@ -29,21 +29,25 @@ fn parse_start_fn(meta: &syn::Meta) -> Result<ItemSigConfig> {
 }
 
 #[cfg(feature = "experimental-build-from")]
-fn parse_build_from(meta: &syn::Meta) -> Result<ItemSigConfig> {
-    ItemSigConfigParsing {
+fn parse_build_from(meta: &syn::Meta) -> Result<Option<ItemSigConfig>> {
+    let config = ItemSigConfigParsing {
         meta,
         reject_self_mentions: Some("builder struct's impl block"),
     }
-    .parse()
+    .parse()?;
+
+    Ok(Some(config))
 }
 
 #[cfg(feature = "experimental-build-from")]
-fn parse_build_from_clone(meta: &syn::Meta) -> Result<ItemSigConfig> {
-    ItemSigConfigParsing {
+fn parse_build_from_clone(meta: &syn::Meta) -> Result<Option<ItemSigConfig>> {
+    let config = ItemSigConfigParsing {
         meta,
         reject_self_mentions: Some("builder struct's impl block"),
     }
-    .parse()
+    .parse()?;
+
+    Ok(Some(config))
 }
 
 #[derive(Debug, FromMeta)]
@@ -86,11 +90,11 @@ pub(crate) struct TopLevelConfig {
 
     #[cfg(feature = "experimental-build-from")]
     #[darling(default, with = parse_build_from)]
-    pub(crate) build_from: ItemSigConfig,
+    pub(crate) build_from: Option<ItemSigConfig>,
 
     #[cfg(feature = "experimental-build-from")]
     #[darling(default, with = parse_build_from_clone)]
-    pub(crate) build_from_clone: ItemSigConfig,
+    pub(crate) build_from_clone: Option<ItemSigConfig>,
 }
 
 impl TopLevelConfig {

--- a/bon-macros/src/builder/builder_gen/top_level_config/mod.rs
+++ b/bon-macros/src/builder/builder_gen/top_level_config/mod.rs
@@ -6,11 +6,11 @@ pub(crate) use on::OnConfig;
 
 use crate::parsing::{BonCratePath, ItemSigConfig, ItemSigConfigParsing, SpannedKey};
 use crate::util::prelude::*;
-use darling::ast::NestedMeta;
 use darling::FromMeta;
+use darling::ast::NestedMeta;
+use syn::ItemFn;
 use syn::parse::Parser;
 use syn::punctuated::Punctuated;
-use syn::ItemFn;
 
 fn parse_finish_fn(meta: &syn::Meta) -> Result<ItemSigConfig> {
     ItemSigConfigParsing::new(meta, Some("builder struct's impl block")).parse()
@@ -65,6 +65,12 @@ pub(crate) struct TopLevelConfig {
     /// Specifies configuration for generic parameter conversion methods.
     #[darling(default, with = crate::parsing::parse_non_empty_paren_meta_list)]
     pub(crate) generics: Option<SpannedKey<GenericsConfig>>,
+
+    #[darling(default)]
+    pub(crate) build_from: bool,
+
+    #[darling(default)]
+    pub(crate) build_from_clone: bool,
 }
 
 impl TopLevelConfig {

--- a/bon-macros/src/builder/builder_gen/top_level_config/mod.rs
+++ b/bon-macros/src/builder/builder_gen/top_level_config/mod.rs
@@ -66,9 +66,11 @@ pub(crate) struct TopLevelConfig {
     #[darling(default, with = crate::parsing::parse_non_empty_paren_meta_list)]
     pub(crate) generics: Option<SpannedKey<GenericsConfig>>,
 
+    #[cfg(feature = "experimental-build-from")]
     #[darling(default)]
     pub(crate) build_from: bool,
 
+    #[cfg(feature = "experimental-build-from")]
     #[darling(default)]
     pub(crate) build_from_clone: bool,
 }

--- a/bon-macros/src/builder/builder_gen/top_level_config/on.rs
+++ b/bon-macros/src/builder/builder_gen/top_level_config/on.rs
@@ -10,6 +10,8 @@ pub(crate) struct OnConfig {
     pub(crate) type_pattern: syn::Type,
     pub(crate) into: Flag,
     pub(crate) overwritable: Flag,
+    #[allow(dead_code)]
+    pub(crate) build_from: Flag,
     pub(crate) required: Flag,
     pub(crate) setters: OnSettersConfig,
 }
@@ -42,6 +44,7 @@ impl Parse for OnConfig {
         struct Parsed {
             into: Flag,
             overwritable: Flag,
+            build_from: Flag,
             required: Flag,
 
             #[darling(default, with = crate::parsing::parse_non_empty_paren_meta_list)]
@@ -70,6 +73,14 @@ impl Parse for OnConfig {
                  double-awesome if you could also describe your use case in \
                  a comment under the issue for us to understand how it's used \
                  in practice",
+            ));
+        }
+
+        if !cfg!(feature = "experimental-build-from") && parsed.build_from.is_present() {
+            return Err(syn::Error::new(
+                parsed.build_from.span(),
+                "🔬 `build_from` attribute is experimental and requires \
+                 \"experimental-build-from\" cargo feature to be enabled.",
             ));
         }
 
@@ -107,6 +118,7 @@ impl Parse for OnConfig {
             type_pattern,
             into: parsed.into,
             overwritable: parsed.overwritable,
+            build_from: parsed.build_from,
             required: parsed.required,
             setters: parsed.setters,
         })

--- a/bon-macros/src/builder/builder_gen/top_level_config/on.rs
+++ b/bon-macros/src/builder/builder_gen/top_level_config/on.rs
@@ -1,6 +1,6 @@
 use crate::util::prelude::*;
-use darling::util::Flag;
 use darling::FromMeta;
+use darling::util::Flag;
 use syn::parse::Parse;
 use syn::spanned::Spanned;
 use syn::visit::Visit;

--- a/bon-macros/src/parsing/item_sig.rs
+++ b/bon-macros/src/parsing/item_sig.rs
@@ -96,3 +96,9 @@ impl<'a> ItemSigConfigParsing<'a> {
         Ok(config)
     }
 }
+
+impl<N: FromMeta> FromMeta for ItemSigConfig<N> {
+    fn from_meta(meta: &syn::Meta) -> darling::Result<Self> {
+        ItemSigConfigParsing::new(meta, None).parse()
+    }
+}

--- a/bon/Cargo.toml
+++ b/bon/Cargo.toml
@@ -92,6 +92,8 @@ experimental-overwritable = ["bon-macros/experimental-overwritable"]
 # generate methods for converting generic parameters on builders.
 experimental-generics-setters = ["bon-macros/experimental-generics-setters"]
 
+experimental-build-from = ["bon-macros/experimental-build-from"]
+
 # Legacy experimental attribute. It's left here for backwards compatibility,
 # and it will be removed in the next major release.
 #

--- a/bon/src/__/ide.rs
+++ b/bon/src/__/ide.rs
@@ -105,6 +105,40 @@ pub mod builder_top_level {
         pub use core::future::IntoFuture;
     }
 
+    /// See the docs at <https://bon-rs.com/reference/builder/top-level/build_from>
+    pub const build_from: Option<Identifier> = None;
+
+    /// See the docs at <https://bon-rs.com/reference/builder/top-level/build_from>
+    pub mod build_from {
+        use super::*;
+
+        /// See the docs at <https://bon-rs.com/reference/builder/top-level/build_from#name>
+        pub const name: Identifier = Identifier;
+
+        /// See the docs at <https://bon-rs.com/reference/builder/top-level/build_from#vis>
+        pub const vis: VisibilityString = VisibilityString;
+
+        /// See the docs at <https://bon-rs.com/reference/builder/top-level/build_from#doc>
+        pub const doc: DocComments = DocComments;
+    }
+
+    /// See the docs at <https://bon-rs.com/reference/builder/top-level/build_from_clone>
+    pub const build_from_clone: Option<Identifier> = None;
+
+    /// See the docs at <https://bon-rs.com/reference/builder/top-level/build_from_clone>
+    pub mod build_from_clone {
+        use super::*;
+
+        /// See the docs at <https://bon-rs.com/reference/builder/top-level/build_from_clone#name>
+        pub const name: Identifier = Identifier;
+
+        /// See the docs at <https://bon-rs.com/reference/builder/top-level/build_from_clone#vis>
+        pub const vis: VisibilityString = VisibilityString;
+
+        /// See the docs at <https://bon-rs.com/reference/builder/top-level/build_from_clone#doc>
+        pub const doc: DocComments = DocComments;
+    }
+
     /// The real name of this parameter is `crate` (without the underscore).
     /// It's hinted with an underscore due to the limitations of the current
     /// completions limitation. This will be fixed in the future.

--- a/bon/tests/integration/builder/build_from.rs
+++ b/bon/tests/integration/builder/build_from.rs
@@ -2,25 +2,52 @@ use crate::prelude::*;
 
 #[derive(Builder, Clone)]
 #[builder(build_from, build_from_clone)]
-struct User {
+struct Sut {
     name: String,
     age: u8,
 }
 
 #[test]
 fn test_build_from_works() {
-    let jon = User::builder().name("Jon".into()).age(25).build();
-    let alice = User::builder().name("Alice".into()).build_from(&jon);
-    assert_eq!(alice.age, jon.age);
+    let jon = Sut::builder().name("Jon".into()).age(25).build();
+    let alice = Sut::builder().name("Alice".into()).build_from(jon);
+    assert_eq!(alice.age, 25);
     assert_eq!(alice.name, "Alice");
 }
 
 #[test]
 fn test_build_from_clone_works() {
-    let jon = User::builder().name("Jon".into()).age(25).build();
-    let alice = User::builder()
-        .name("Alice".into())
-        .build_from_clone(jon.clone());
-    assert_eq!(alice.age, jon.age);
+    let jon = Sut::builder().name("Jon".into()).age(25).build();
+    let alice = Sut::builder().name("Alice".into()).build_from_clone(&jon);
+    assert_eq!(alice.age, 25);
+    assert_eq!(alice.name, "Alice");
+}
+
+#[builder(build_from, build_from_clone)]
+fn create_user(name: String, age: u8) -> Sut {
+    Sut { name, age }
+}
+
+#[test]
+fn test_function_build_from_works() {
+    let jon = create_user().name("Jon".into()).age(25).call();
+    let alice = create_user().name("Alice".into()).call_from(jon);
+    assert_eq!(alice.age, 25);
+    assert_eq!(alice.name, "Alice");
+}
+
+#[bon]
+impl Sut {
+    #[builder(build_from, build_from_clone)]
+    fn from_parts(name: String, age: u8) -> Self {
+        Self { name, age }
+    }
+}
+
+#[test]
+fn test_method_build_from_clone_works() {
+    let jon = Sut::from_parts().name("Jon".into()).age(25).call();
+    let alice = Sut::from_parts().name("Alice".into()).call_from_clone(&jon);
+    assert_eq!(alice.age, 25);
     assert_eq!(alice.name, "Alice");
 }

--- a/bon/tests/integration/builder/build_from.rs
+++ b/bon/tests/integration/builder/build_from.rs
@@ -1,0 +1,26 @@
+use crate::prelude::*;
+
+#[derive(Builder, Clone)]
+#[builder(build_from, build_from_clone)]
+struct User {
+    name: String,
+    age: u8,
+}
+
+#[test]
+fn test_build_from_works() {
+    let jon = User::builder().name("Jon".into()).age(25).build();
+    let alice = User::builder().name("Alice".into()).build_from(&jon);
+    assert_eq!(alice.age, jon.age);
+    assert_eq!(alice.name, "Alice");
+}
+
+#[test]
+fn test_build_from_clone_works() {
+    let jon = User::builder().name("Jon".into()).age(25).build();
+    let alice = User::builder()
+        .name("Alice".into())
+        .build_from_clone(jon.clone());
+    assert_eq!(alice.age, jon.age);
+    assert_eq!(alice.name, "Alice");
+}

--- a/bon/tests/integration/builder/build_from.rs
+++ b/bon/tests/integration/builder/build_from.rs
@@ -51,3 +51,80 @@ fn test_method_build_from_clone_works() {
     assert_eq!(alice.age, 25);
     assert_eq!(alice.name, "Alice");
 }
+
+#[test]
+fn test_build_from_path_and_generics() {
+    {
+        pub(crate) mod models {
+            #[derive(Debug, PartialEq)]
+            pub(crate) struct Sut<T> {
+                pub(crate) value: T,
+                pub(crate) flag: bool,
+            }
+        }
+        #[derive(Builder)]
+        #[builder(build_from)]
+        struct Source {
+            value: String,
+            flag: bool,
+        }
+        let src = Source::builder()
+            .value("Veetah".to_string())
+            .flag(true)
+            .build();
+
+        let actual = models::Sut::<String> {
+            value: src.value,
+            flag: src.flag,
+        };
+        assert_eq!(actual.value, "Veetah");
+    }
+}
+
+#[test]
+fn test_build_from_custom_vis_and_docs() {
+    {
+        pub(crate) mod external {
+            use crate::prelude::*;
+
+            #[derive(Builder, Clone)]
+            #[builder(build_from)]
+            pub(crate) struct Source {
+                pub(crate) id: u32,
+            }
+        }
+        let base = external::Source::builder().id(99).build();
+        let actual = external::Source::builder().build_from(base);
+        assert_eq!(actual.id, 99);
+    }
+}
+
+#[test]
+fn test_build_from_nested_path_and_generics_enforcement() {
+    {
+        pub(crate) mod complex_namespace {
+            pub(crate) mod deeply_nested {
+                pub(crate) struct TargetSut<T> {
+                    pub(crate) data: String,
+                    pub(crate) extra: T,
+                }
+            }
+        }
+        #[builder(build_from)]
+        fn create_complex_target(
+            data: String,
+            extra: u32,
+        ) -> complex_namespace::deeply_nested::TargetSut<u32> {
+            complex_namespace::deeply_nested::TargetSut { data, extra }
+        }
+        let base = complex_namespace::deeply_nested::TargetSut {
+            data: "BaseData".to_string(),
+            extra: 100u32,
+        };
+        let actual = create_complex_target()
+            .data("Veetah".to_string())
+            .call_from(base);
+        assert_eq!(actual.data, "Veetah");
+        assert_eq!(actual.extra, 100);
+    }
+}

--- a/bon/tests/integration/builder/mod.rs
+++ b/bon/tests/integration/builder/mod.rs
@@ -16,6 +16,7 @@ mod attr_setters;
 mod attr_skip;
 mod attr_top_level_start_fn;
 mod attr_with;
+mod build_from;
 mod cfgs;
 mod generics;
 #[cfg(feature = "experimental-generics-setters")]

--- a/bon/tests/integration/builder/mod.rs
+++ b/bon/tests/integration/builder/mod.rs
@@ -16,6 +16,7 @@ mod attr_setters;
 mod attr_skip;
 mod attr_top_level_start_fn;
 mod attr_with;
+#[cfg(feature = "experimental-build-from")]
 mod build_from;
 mod cfgs;
 mod generics;


### PR DESCRIPTION
# Add `build_from` and `build_from_clone` builder methods

Closes #310

This PR is a fresh continuation of the original #313 , which I accidentally closed when rebasing my master branch. I have since transplanted my work on here:

## Original PR Overview

This PR adds support for two new optional top-level builder attributes:

- `#[builder(build_from)]` – Adds a `.build_from(T)` / `.call_from(T)` method (takes `T` by value).
- `#[builder(build_from_clone)]` – Adds a `.build_from_clone(&T)` / `.call_from_clone(&T)` method (takes `&T` and clones fields).

These methods allow partially configured builders to fill in missing fields from an existing instance of the target type before finalizing the build. This is useful when:

1. You want to override only a few fields but reuse most of the existing data.
2. You're working with types that aren't `Default`, making field reuse non-trivial.

## Example

Rust

```
#[derive(Builder, Clone)]
#[builder(build_from, build_from_clone)]
struct User {
    name: String,
    age: u8,
}

let jon = User::builder().name("Jon".into()).age(25).build();
let alice = User::builder().name("Alice".into()).build_from_clone(&jon);

assert_eq!(alice.name, "Alice");
assert_eq!(alice.age, 25);
```

## Implementation Notes

- The code generation engine lives in `builder_gen/build_from.rs` and is conditionally compiled/emitted via the `experimental-build-from` feature flag.
- Integrating `ItemSigConfig` directly into `darling::FromMeta` allows native attribute parsing without structural wrapper types.
- Each field is handled according to its member kind:
  - **Named fields:** Fallback to the instance data if not explicitly set in the builder state.
  - **FinishFn fields:** Defer to the instance data.
  - **Skip fields:** Drop back to `Default::default()`.

## WIP Status & Next Steps

This PR is currently open as a **Draft / WIP**. Before marking it ready for full review, I am working on polishing a few key items:

- [ ] **Inherit Attributes:** Ensure that custom visibility (`vis`) and documentation (`doc`) passed inside `#[builder(build_from(...))]` are properly inherited by the generated methods.
- [ ] **Function/Method Builders:** Refactor code generation to correctly support `bon` when applied to functions or associated methods (ensuring we invoke the execution block rather than blindly emitting a structural literal path).
- [ ] **Expanded Integration Tests:** Adding test coverage for complex namespaces, turbofish paths, and custom vis/doc combinations.