### PR TITLE
feat: support the default switch in the on(...) clause

### DIFF
--- a/bon-macros/src/builder/builder_gen/member/named.rs
+++ b/bon-macros/src/builder/builder_gen/member/named.rs
@@ -263,6 +263,8 @@ impl NamedMember {
     }
 
     pub(crate) fn merge_on_config(&mut self, on: &[OnConfig]) -> Result {
+        self.merge_config_default(on)?;
+
         // This is a temporary hack. We only allow `on(_, required)` as the
         // first `on(...)` clause. Instead we should implement the extended design:
         // https://github.com/elastio/bon/issues/152
@@ -286,6 +288,35 @@ impl NamedMember {
             origin: self.origin,
         }
         .eval()?;
+
+        Ok(())
+    }
+
+    /// Applies `on(type_pattern, default)` to this member. It turns a matching
+    /// *required* member into an optional one that falls back to its `Default`
+    /// value. Members that already have a default, and `Option<T>` members
+    /// (which already default to `None`), are left untouched, so this never
+    /// overrides a more specific member-level `#[builder(default = ...)]`.
+    fn merge_config_default(&mut self, on: &[OnConfig]) -> Result {
+        if !self.is_required() {
+            return Ok(());
+        }
+
+        let scrutinee = self.underlying_orig_ty();
+
+        let matched = on
+            .iter()
+            .filter(|params| params.default.is_present())
+            .map(|params| Ok((params, scrutinee.matches(&params.type_pattern)?)))
+            .collect::<Result<Vec<_>>>()?
+            .into_iter()
+            .find(|(_, matched)| *matched)
+            .map(|(params, _)| params);
+
+        if let Some(params) = matched {
+            let key = syn::Ident::new("default", params.default.span());
+            self.config.default = Some(SpannedKey { key, value: None });
+        }
 
         Ok(())
     }

--- a/bon-macros/src/builder/builder_gen/top_level_config/on.rs
+++ b/bon-macros/src/builder/builder_gen/top_level_config/on.rs
@@ -11,6 +11,7 @@ pub(crate) struct OnConfig {
     pub(crate) into: Flag,
     pub(crate) overwritable: Flag,
     pub(crate) required: Flag,
+    pub(crate) default: Flag,
     pub(crate) setters: OnSettersConfig,
 }
 
@@ -43,6 +44,7 @@ impl Parse for OnConfig {
             into: Flag,
             overwritable: Flag,
             required: Flag,
+            default: Flag,
 
             #[darling(default, with = crate::parsing::parse_non_empty_paren_meta_list)]
             setters: OnSettersConfig,
@@ -108,6 +110,7 @@ impl Parse for OnConfig {
             into: parsed.into,
             overwritable: parsed.overwritable,
             required: parsed.required,
+            default: parsed.default,
             setters: parsed.setters,
         })
     }

--- a/bon/tests/integration/builder/attr_on.rs
+++ b/bon/tests/integration/builder/attr_on.rs
@@ -70,3 +70,71 @@ fn match_generic() {
 
     sut().arg1(true).arg2(()).arg3(IntoGeneric("foo")).call();
 }
+
+#[test]
+fn default_match_path() {
+    #[derive(Debug, Builder)]
+    #[builder(on(u32, default))]
+    #[allow(dead_code)]
+    struct Sut {
+        x: u32,
+        y: u32,
+
+        // A member-level default with a value wins over `on(u32, default)`.
+        #[builder(default = 42)]
+        z: u32,
+    }
+
+    assert_debug_eq(Sut::builder().build(), expect!["Sut { x: 0, y: 0, z: 42 }"]);
+
+    assert_debug_eq(
+        Sut::builder().x(1).y(2).z(3).build(),
+        expect!["Sut { x: 1, y: 2, z: 3 }"],
+    );
+}
+
+#[cfg(feature = "alloc")]
+#[test]
+fn default_match_generic() {
+    #[derive(Debug, Builder)]
+    #[builder(on(Vec<_>, default))]
+    #[allow(dead_code)]
+    struct Sut {
+        // `name` doesn't match `Vec<_>`, so it stays required.
+        name: String,
+        tags: Vec<String>,
+        ids: Vec<u32>,
+    }
+
+    assert_debug_eq(
+        Sut::builder().name("bon".to_owned()).build(),
+        expect![[r#"Sut { name: "bon", tags: [], ids: [] }"#]],
+    );
+
+    assert_debug_eq(
+        Sut::builder()
+            .name("bon".to_owned())
+            .tags(vec!["x".to_owned()])
+            .ids(vec![7])
+            .build(),
+        expect![[r#"Sut { name: "bon", tags: ["x"], ids: [7] }"#]],
+    );
+}
+
+#[cfg(feature = "alloc")]
+#[test]
+fn default_with_into() {
+    #[builder(on(String, into, default))]
+    fn sut(name: String, level: u32) -> impl core::fmt::Debug {
+        (name, level)
+    }
+
+    // `name` matched `String`, so it accepts `impl Into<String>` and defaults
+    // to an empty string; `level` didn't match, so it stays required.
+    assert_debug_eq(sut().level(1).call(), expect![[r#"("", 1)"#]]);
+
+    assert_debug_eq(
+        sut().name("bon").level(2).call(),
+        expect![[r#"("bon", 2)"#]],
+    );
+}

--- a/website/src/reference/builder/top-level/on.md
+++ b/website/src/reference/builder/top-level/on.md
@@ -97,6 +97,7 @@ There are several attributes supported in the `attributes` position listed below
 
 - [`into`](../member/into)
 - [`required`](../member/required) - currently, this attribute can only be used with the `_` type pattern as the first `on(...)` clause
+- [`default`](../member/default) - applies `#[builder(default)]` to matching required members so they fall back to their `Default` value; passing a custom default value through `on(...)` isn't supported yet (see the issue [#152](https://github.com/elastio/bon/issues/152))
 - [`setters(doc(default(skip)))`](../member/setters#doc-default-skip)
 - [`overwritable`](../member/overwritable) - 🔬 **experimental**, this attribute is available under the cargo feature `"experimental-overwritable"` (see the issue [#149](https://github.com/elastio/bon/issues/149))
 
@@ -126,6 +127,24 @@ Example::builder()
     // so `#[builder(into)]` was applied to them
     .description("accepts an `impl Into<String>` here")
     .alias("builder")
+    .build();
+```
+
+```rust [default]
+use bon::Builder;
+
+#[derive(Builder)]
+#[builder(on(Vec<_>, default))] // [!code highlight]
+struct Example {
+    name: String,
+    // These `Vec<_>` members become optional and default to an empty `Vec`
+    tags: Vec<String>,
+    ids: Vec<u32>,
+}
+
+Example::builder()
+    // Only `name` is required now
+    .name("Bon".to_owned())
     .build();
 ```
 
@@ -209,4 +228,4 @@ Example::builder()
 
 ## Future Releases
 
-There is an issue [#152](https://github.com/elastio/bon/issues/152) about adding support for [`default`](../member/default.md), [`with`](../member/with) and other non-boolean attributes to the `on(...)` clause. We'll be glad if you take a look at the design proposed in that issue and put a 👍 if you like/want this feature or leave a comment if you have some more feedback.
+The `default` attribute above is currently only a boolean switch. There is an issue [#152](https://github.com/elastio/bon/issues/152) about adding support for non-boolean attributes to the `on(...)` clause, such as a custom `default = ...` value, [`with`](../member/with) and others. We'll be glad if you take a look at the design proposed in that issue and put a 👍 if you like/want this feature or leave a comment if you have some more feedback.


### PR DESCRIPTION
Closes #366.

This adds `default` as a switch in the `on(...)` clause, so you can write `#[builder(on(Vec<_>, default))]` to make every matching required member optional and fall back to its `Default` value. It's the boolean form from your comment on the issue, so a custom `default = ...` value is still left to #152.

Members that already have a `#[builder(default = ...)]` or are `Option<T>` are left untouched, so this doesn't change anything for existing builders. I wired it into the same type-pattern matching that `into` and `overwritable` use, added tests to `attr_on.rs`, and documented the attribute on the `on` reference page.
